### PR TITLE
refactor: stderr/stdout

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -39,8 +39,9 @@ runs:
       shell: bash
       run: >
         repo-review .
-        --stderr html
+        --format html
+        --stderr rich
         --select "${{ inputs.select }}"
         --ignore "${{ inputs.ignore }}"
         --package-dir "${{ inputs.package-dir }}"
-        2> $GITHUB_STEP_SUMMARY
+        >> $GITHUB_STEP_SUMMARY

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,8 +10,8 @@ There are four output formats; `rich` produces great terminal output, `svg`
 produces an SVG based on the rich output, `html` produces a custom HTML report,
 and `json` produces a output that can be processed easily. To make it easier to
 support tools like GitHub Actions, there is also a `--stderr FORMAT` output
-option that produces the selected format on stderr as well, and avoids producing
-terminal escape codes, even if `FORCE_COLOR` is set.
+option that produces the selected format on stderr as well, and disables
+producing terminal escape codes on stdout, even if `FORCE_COLOR` is set.
 
 JSON output looks like this:
 

--- a/docs/index.html
+++ b/docs/index.html
@@ -63,7 +63,7 @@
       root.render(
         <App
           header={true}
-          deps={["sp_repo_review==2023.06.01", "repo-review==0.7.0b6"]}
+          deps={["sp_repo_review==2023.06.01", "repo-review==0.7.0b7"]}
         />,
       );
     </script>

--- a/docs/plugins.md
+++ b/docs/plugins.md
@@ -8,6 +8,19 @@ standardized backend, such as `hatchling`, `flit-core`, `pdm-backend`, or
 `setuptools>=61`. If you are using some other build backend, please adjust
 accordingly.
 
+## Avoiding CLI requirements on WebAssembly usage
+
+Repo-review uses `repo-review[cli]` to keep CLI requirements from being
+included in the base package, and plugins can follow this if they want to be
+used directly:
+
+```toml
+[project.optional-dependencies]
+cli = [
+  "repo-review[cli]",
+]
+```
+
 ## Custom entry-point (optional)
 
 If you want to provide your own CLI name, you can
@@ -52,7 +65,7 @@ a subset of files (which most should).
 
 ## GitHub Actions support
 
-You can add an `actions.yml` file similar to this to natively support GitHub
+You can add an `action.yml` file similar to this to natively support GitHub
 Actions & dependabot:
 
 ```yaml
@@ -78,11 +91,12 @@ runs:
       run: >
         pipx run
         --python '${{ steps.python.outputs.python-path }}'
-        --spec '${{ github.action_path }}'
+        --spec '${{ github.action_path }}[cli]'
         repo-review .
-        --stderr html
+        --format html
+        --stderr rich
         --select "${{ inputs.select }}"
         --ignore "${{ inputs.ignore }}"
         --package-dir "${{ inputs.package-dir }}"
-        2> $GITHUB_STEP_SUMMARY
+        >> $GITHUB_STEP_SUMMARY
 ```

--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -28,6 +28,13 @@ from .ghpath import GHPath
 from .html import to_html
 from .processor import Result, _collect_all, as_simple_dict, process
 
+__all__ = ["main"]
+
+
+def __dir__() -> list[str]:
+    return __all__
+
+
 rich.traceback.install(suppress=[click, rich], show_locals=True, width=None)
 
 


### PR DESCRIPTION
This flips the meaning of stderr/stdout, making stdout the one that is good for redirection, and stderr the one that is expected to show up on the console.

- fix: nicer form for making GHA
- chore: mark public api in `__main__`
