### PR TITLE
feat: drop formatting of dynamic messages

### DIFF
--- a/docs/checks.md
+++ b/docs/checks.md
@@ -32,6 +32,11 @@ string from the check instead of `False`. Returning `None` makes a check
 and check name with `{name}` (these are processed with `.format()`, so escape `{}`
 as `{{}}`). The error message is in markdown format.
 
+```{versionchanged} 0.9
+The string return value is not processed via `.format`. You can use `self` and
+the `name` fixture directly when constructing the return string.
+```
+
 If the check named in `requires` does not pass, the check is skipped.
 
 A suggested convention for easily writing checks is as follows:

--- a/docs/fixtures.md
+++ b/docs/fixtures.md
@@ -1,11 +1,20 @@
 # Fixtures
 
-Like pytest fixtures, fixtures in repo-review are requested by name. There are four built-in fixtures:
+Like pytest fixtures, fixtures in repo-review are requested by name. There are five built-in fixtures:
 
 - `root`: {class}`~importlib.resources.abc.Traversable` - The repository path. All checks or fixtures that depend on the root of the repository should use this.
 - `package`: `~importlib.resources.abc.Traversable` - The path to the package directory. This is the same as `root` unless `--package-dir` is passed.
+- `name`: `str` - The name of the current check. (Special fixture only provided for checks, not collection functions.)
 - {func}`~repo_review.fixtures.pyproject`: `dict[str, Any]` - The `pyproject.toml` in the package if it exists, an empty dict otherwise.
-- {func}`~repo_review.fixtures.list_all`: `bool` - returns True if repo-review is just trying to collect all checks to list them.
+- {func}`~repo_review.fixtures.list_all`: `bool` - Returns `True`` if repo-review is just trying to collect all checks to list them.
+
+```{versionadded} 0.8
+The `list_all` fixture.
+```
+
+```{versionadded} 0.9
+The `name` fixture for checks.
+```
 
 Repo-review doesn't necessarily assume any form or language for your repository,
 but since it already looks for configuration in `pyproject.toml`, this fixture

--- a/src/repo_review/processor.py
+++ b/src/repo_review/processor.py
@@ -194,9 +194,15 @@ def process(
     ts = graphlib.TopologicalSorter(graph)
     for name in ts.static_order():
         if all(completed.get(n, "") == "" for n in graph[name]):
-            result = apply_fixtures(fixtures, tasks[name].check)
+            result = apply_fixtures({"name": name, **fixtures}, tasks[name].check)
             if isinstance(result, bool):
-                completed[name] = "" if result else tasks[name].check.__doc__
+                completed[name] = (
+                    ""
+                    if result
+                    else (tasks[name].check.__doc__ or "Check failed").format(
+                        name=name, self=tasks[name].check
+                    )
+                )
             else:
                 completed[name] = result
         else:
@@ -218,7 +224,7 @@ def process(
                 name=task_name,
                 description=doc.format(self=check, name=task_name).strip(),
                 result=result,
-                err_msg=textwrap.dedent(err_msg.format(self=check, name=task_name)),
+                err_msg=textwrap.dedent(err_msg),
                 url=get_check_url(task_name, check),
             )
         )

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -45,9 +45,9 @@ class C100:
     fail: bool
     family: ClassVar[str] = "custom"
 
-    def check(self) -> str:
+    def check(self, name: str) -> str:
         "Never see me"
-        return "I'm a custom error message" if self.fail else ""
+        return f"I'm a custom error message from {name}" if self.fail else ""
 
 
 def test_no_checks(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -156,4 +156,4 @@ def test_string_result(monkeypatch: pytest.MonkeyPatch) -> None:
 
     assert check_c101.name == "C101"
     assert check_c101.result is False
-    assert check_c101.err_msg == "I'm a custom error message"
+    assert check_c101.err_msg == "I'm a custom error message from C101"


### PR DESCRIPTION
Drop running '.format' on dynamic strings. It's hard to ensure they don't have `{}` in them, and you can access this info when building the string yourself. Added a special `name` fixture that allows easy access to the name of the current check.
