### PR TITLE
feat: allow passing the path to pyroject.toml

### DIFF
--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -26,6 +26,10 @@ def test_cmd_basic():
     subprocess.run(["repo-review", "."], check=True)
 
 
+def test_cmd_pyproject():
+    subprocess.run(["repo-review", "pyproject.toml"], check=True)
+
+
 def test_cmd_html():
     subprocess.run(
         ["repo-review", ".", "--format", "html", "--stderr", "html"], check=True


### PR DESCRIPTION
Special case passing `<path>/pyproject.toml`, to make it easier to loop over a directory with mixed repos.
