### PR TITLE
feat: allow running on multiple directories at once

### DIFF
--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -86,11 +86,13 @@ def rich_printer(
     if header:
         console.print(rich.markdown.Markdown(f"# {header}"))
 
-    for family, results_list in itertools.groupby(processed, lambda r: r.family):
-        # Compute the family name and optional description
+    for family in families:
         family_name = get_family_name(families, family)
-        rich_family_name = rich.text.Text.from_markup(f"[bold]{family_name}[/bold]:")
         family_description = get_family_description(families, family)
+        family_results = [r for r in processed if r.family == family]
+
+        # Compute the family name and optional description
+        rich_family_name = rich.text.Text.from_markup(f"[bold]{family_name}[/bold]:")
         if family_description:
             rich_description = rich.markdown.Markdown(family_description)
             rich_family = rich.console.Group(
@@ -100,7 +102,7 @@ def rich_printer(
         else:
             tree = rich.tree.Tree(rich_family_name)
 
-        for result in results_list:
+        for result in family_results:
             style = (
                 "yellow"
                 if result.result is None
@@ -129,8 +131,9 @@ def rich_printer(
                 msg_grp = rich.console.Group(msg, detail)
                 tree.add(msg_grp)
 
-        console.print(tree)
-        console.print()
+        if family_results or family_description:
+            console.print(tree)
+            console.print()
 
     if header:
         console.print()

--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -199,7 +199,9 @@ def display_output(
         case "html":
             html = to_html(families, processed, status)
             if header:
-                html = f"<h1>{header}</h1>\n{html}<hr/>\n"
+                failures = sum(r.result is False for r in processed)
+                status_msg = f"({failures} failed)" if failures else "(all passed)"
+                html = f"<details><summary><h2>{header}</h2>: {status_msg}</summary>\n{html}</details>\n"
             if color and output.isatty():
                 # We check isatty even though Rich does too because Rich
                 # injects a ton of ending whitespace even going to a file

--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -164,6 +164,7 @@ def display_output(
     status: Status,
     header: str,
 ) -> None:
+    output = sys.stderr if stderr else sys.stdout
     match format_opt:
         case "rich" | "svg":
             rich_printer(
@@ -188,6 +189,7 @@ def display_output(
                 stderr=stderr, color_system="auto" if color else None
             )
             if header:
+                # We strip off beginning and ending brackets
                 console.print(j.__rich__()[2:-2], end="")
             else:
                 console.print(j)
@@ -195,13 +197,15 @@ def display_output(
             html = to_html(families, processed, status)
             if header:
                 html = f"<h1>{header}</h1>\n{html}<hr/>\n"
-            if color:
+            if color and output.isatty():
+                # We check isatty even though Rich does too because Rich
+                # injects a ton of ending whitespace even going to a file
                 rich.print(
                     rich.syntax.Syntax(html, lexer="html"),
-                    file=sys.stderr if stderr else sys.stdout,
+                    file=output,
                 )
             else:
-                print(html, file=sys.stderr if stderr else sys.stdout)
+                print(html, file=output)
         case _:
             assert_never(format_opt)
 

--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import itertools
+import json
 import sys
 import typing
 from collections.abc import Mapping
@@ -187,15 +188,21 @@ def display_output(
             }
             if header:
                 d = {header: d}
-            j = rich.json.JSON.from_data(d)
-            console = rich.console.Console(
-                stderr=stderr, color_system="auto" if color else None
-            )
-            if header:
-                # We strip off beginning and ending brackets
-                console.print(j.__rich__()[2:-2], end="")
+
+            if color and output.isatty():
+                j = rich.json.JSON.from_data(d)
+                console = rich.console.Console(stderr=stderr, color_system="auto")
+                if header:
+                    # We strip off beginning and ending brackets
+                    console.print(j.__rich__()[2:-2], end="")
+                else:
+                    console.print(j)
             else:
-                console.print(j)
+                # Rich wraps json, which breaks it
+                if header:
+                    print(json.dumps(d, indent=2)[2:-2])
+                else:
+                    print(json.dumps(d, indent=2))
         case "html":
             html = to_html(families, processed, status)
             if header:

--- a/src/repo_review/html.py
+++ b/src/repo_review/html.py
@@ -44,7 +44,7 @@ def to_html(
         family_description = get_family_description(families, family)
         family_results = [r for r in processed if r.family == family]
         if family_results or family_description:
-            print(f"<h2>{family_name}</h2>")
+            print(f"<h3>{family_name}</h3>")
         if family_description:
             print(md.render(family_description))
         if family_results:

--- a/src/repo_review/processor.py
+++ b/src/repo_review/processor.py
@@ -139,7 +139,8 @@ def collect_all(
     :param root: If passed, this is the root of the repo (for fixture computation).
     :param subdir: The subdirectory (for fixture computation).
 
-    :return: The collected fixtures, checks, and families.
+    :return: The collected fixtures, checks, and families. Families is
+             guaranteed to include all families and be in order.
 
     .. versionadded:: 0.8
     """
@@ -182,7 +183,8 @@ def process(
     :param subdir: The path to the package in the subdirectory, if not at the
                    root of the repository.
 
-    :return: A dictionary of check results.
+    :return: The families and a list of checks. Families is guaranteed to
+             include all families and be in order.
     """
     package = root.joinpath(subdir) if subdir else root
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,38 @@
+import importlib.metadata
+
+import pytest
+
+
+@pytest.fixture()
+def no_entry_points(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        importlib.metadata, "entry_points", lambda group: []  # noqa: ARG005
+    )
+
+
+@pytest.fixture()
+def local_entry_points(monkeypatch: pytest.MonkeyPatch) -> None:
+    orig_ep = importlib.metadata.entry_points
+    ep1 = importlib.metadata.EntryPoint(
+        name="pyproject",
+        group="repo_review.checks",
+        value="pyproject:repo_review_checks",
+    )
+    ep2 = importlib.metadata.EntryPoint(
+        name="pyproject",
+        group="repo_review.families",
+        value="pyproject:repo_review_families",
+    )
+
+    def new_ep(*, group: str) -> list[importlib.metadata.EntryPoint]:
+        if group == "repo_review.checks":
+            return [ep1]
+        if group == "repo_review.families":
+            return [ep2]
+        if group == "repo_review.fixtures":
+            return [
+                e for e in orig_ep(group=group) if e.module.startswith("repo_review.")
+            ]
+        return orig_ep(group=group)
+
+    monkeypatch.setattr(importlib.metadata, "entry_points", new_ep)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,12 @@ import importlib.metadata
 import pytest
 
 
+@pytest.fixture(autouse=True)
+def nocolor(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NOCOLOR", raising=False)
+    monkeypatch.delenv("FORCE_COLOR", raising=False)
+
+
 @pytest.fixture()
 def no_entry_points(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(

--- a/tests/test_cmd.py
+++ b/tests/test_cmd.py
@@ -30,6 +30,10 @@ def test_cmd_pyproject():
     subprocess.run(["repo-review", "pyproject.toml"], check=True)
 
 
+def test_cmd_dual():
+    subprocess.run(["repo-review", "../repo-review", "../repo-review"], check=True)
+
+
 def test_cmd_html():
     subprocess.run(
         ["repo-review", ".", "--format", "html", "--stderr", "html"], check=True

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -1,0 +1,72 @@
+import json
+import textwrap
+import xml.etree.ElementTree as ET
+from collections.abc import Sequence
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from repo_review.__main__ import main
+
+
+@pytest.fixture()
+def multiple_packages(tmp_path: Path) -> tuple[str, str]:
+    packages = (tmp_path / "package_1", tmp_path / "package_2")
+
+    for package in packages:
+        package.mkdir()
+
+        basic_toml = textwrap.dedent(
+            """\
+            [build-system]
+            requires = ["somepackage"]
+            build-backend="somebackend"
+
+            [tool.pytest.ini_options]
+            minversion = "6.0"
+            """
+        )
+
+        package.joinpath("pyproject.toml").write_text(basic_toml)
+        package.joinpath(".pre-commit-config.yaml").touch()
+        package.joinpath("README.md").touch()
+
+        package.joinpath("docs").mkdir()
+        package.joinpath("tests").mkdir()
+
+    return (str(packages[0]), str(packages[1]))
+
+
+@pytest.mark.usefixtures("local_entry_points")
+def test_multiple_packages_rich(multiple_packages: Sequence[str]) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, [*multiple_packages])
+    assert result.exit_code == 0
+    assert "package_1" in result.output
+    assert "package_2" in result.output
+    assert "Has somebackend backend" in result.output
+
+
+@pytest.mark.usefixtures("local_entry_points")
+def test_multiple_packages_json(multiple_packages: Sequence[str]) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, [*multiple_packages, "--format", "json"])
+    assert result.exit_code == 0
+    output = json.loads(result.output)
+    assert len(output) == 2
+    assert "package_1" in output
+    assert "package_2" in output
+
+
+@pytest.mark.usefixtures("local_entry_points")
+def test_multiple_packages_html(multiple_packages: Sequence[str]) -> None:
+    runner = CliRunner()
+    result = runner.invoke(main, [*multiple_packages, "--format", "html"])
+    assert result.exit_code == 0
+    tree = ET.fromstring(f"<body>{result.output}</body>")
+    assert len(tree) == 2
+    assert tree[0].tag == "details"
+    assert tree[0][0][0].text == "package_1"
+    assert tree[0][0][0].tail == ": (all passed)"
+    assert tree[1][0][0].text == "package_2"

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -1,4 +1,3 @@
-import importlib.metadata
 from pathlib import Path
 
 import pytest
@@ -7,31 +6,8 @@ import repo_review.processor
 
 
 @pytest.fixture(autouse=True)
-def patch_entry_points(monkeypatch: pytest.MonkeyPatch) -> None:
-    orig_ep = importlib.metadata.entry_points
-    ep1 = importlib.metadata.EntryPoint(
-        name="pyproject",
-        group="repo_review.checks",
-        value="pyproject:repo_review_checks",
-    )
-    ep2 = importlib.metadata.EntryPoint(
-        name="pyproject",
-        group="repo_review.families",
-        value="pyproject:repo_review_families",
-    )
-
-    def new_ep(*, group: str) -> list[importlib.metadata.EntryPoint]:
-        if group == "repo_review.checks":
-            return [ep1]
-        if group == "repo_review.families":
-            return [ep2]
-        if group == "repo_review.fixtures":
-            return [
-                e for e in orig_ep(group=group) if e.module.startswith("repo_review.")
-            ]
-        return orig_ep(group=group)
-
-    monkeypatch.setattr(importlib.metadata, "entry_points", new_ep)
+def patch_entry_points(local_entry_points: object) -> None:  # noqa: ARG001
+    pass
 
 
 def test_pyproject() -> None:


### PR DESCRIPTION
~~JSON is not working correctly yet.~~ Needs some tests.

This takes 3.5 seconds to check every repo in scikit-hep (using all-repos to clone beforehand). While a manual loop took 11.1 seconds, due to needing to reload Python process every time. :)

To run:

```bash
# Setup all repos to pull what you want, like Scikit-HEP
all-repos-clone
cd output/<name>
repo-review */pyproject.toml --show=err --format html > output.html
```

~~I've noticed the way HTML works, it can't print non-existent families that have descriptions.~~ Fixed. I think for now this makes the most sense, since you want to see the report-style descriptions.