### PR TITLE
fix: drop Rich color printout for html & JSON

### DIFF
--- a/src/repo_review/html.py
+++ b/src/repo_review/html.py
@@ -46,7 +46,7 @@ def to_html(
         if family_results or family_description:
             print(f"<h3>{family_name}</h3>")
         if family_description:
-            print(md.render(family_description))
+            print(md.render(family_description).strip())
         if family_results:
             print("<table>")
             print("<tr><th>?</th><th>Name</th><th>Description</th></tr>")
@@ -58,7 +58,13 @@ def to_html(
                 if result.result
                 else "red"
             )
-            icon = "⚠️" if result.result is None else "✅" if result.result else "❌"
+            icon = (
+                "&#9888;&#65039;"
+                if result.result is None
+                else "&#9989;"
+                if result.result
+                else "&#10060;"
+            )
             result_txt = (
                 "Skipped"
                 if result.result is None


### PR DESCRIPTION
Drops the color printout for html & json. Rich adds spaces, making it about 5-10 bigger in number of chars (which can cause it to go past the 65K char limit for GitHub comments), and it also wraps, which makes JSON unparsable if there's a long string (like a URL). This happens even if you redirect to a file (only color codes are stripped, not wrapping or whitespace). This lets us drop our workarounds. Someone can send json to jq if they need color.

Followup to #134.