### PR TITLE
fix: support '*' for select

### DIFF
--- a/src/repo_review/checks.py
+++ b/src/repo_review/checks.py
@@ -76,13 +76,18 @@ def is_allowed(select: Set[str], ignore: Set[str], name: str) -> bool:
     number is in the ignore list. If the select list is not empty, only runs the
     check if the name or name without the number is in the select list.
 
-    :param select: A set of names or prefixes to include.
+    :param select: A set of names or prefixes to include. "*" selects all checks.
     :param ignore: A set of names or prefixes to exclude.
     :param name: The check to test.
 
     :return: True if this check is allowed, False otherwise.
     """
-    if select and name not in select and name.rstrip("0123456789") not in select:
+    if (
+        select
+        and name not in select
+        and name.rstrip("0123456789") not in select
+        and "*" not in select
+    ):
         return False
     if name in ignore or name.rstrip("0123456789") in ignore:
         return False

--- a/tests/test_checks.py
+++ b/tests/test_checks.py
@@ -138,6 +138,17 @@ def test_select_filter_exact(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(results) == 1
 
 
+def test_select_filter_all(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        repo_review.processor,
+        "collect_checks",
+        lambda _: {"D100": D100(), "D200": D200(), "C100": C100(fail=True)},
+    )
+    _, results = repo_review.processor.process(Path(), select={"*"})
+
+    assert len(results) == 3
+
+
 def test_string_result(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         repo_review.processor,


### PR DESCRIPTION
Small feature to allow the command line to override a config file. Close #136.