### PR TITLE
ci: group dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,3 +5,7 @@ updates:
     directory: "/"
     schedule:
       interval: "daily"
+    groups:
+      actions:
+        patterns:
+          - "*"


### PR DESCRIPTION
Somewhat recently added, is much better for things like upload/download-artifact's v4 update!
