### PR TITLE
fix: ensure utf-8 encoding if something else is default and unset

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,6 +49,7 @@ jobs:
             3.10
             3.11
             3.12
+            3.13
 
       - name: Setup uv
         uses: yezz123/setup-uv@v4
@@ -58,8 +59,6 @@ jobs:
 
       - name: Test package (all Pythons)
         run: hatch test -a
-        env:
-          PYTHONUTF8: "1"
 
   dist:
     name: Distribution build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
             3.11
             3.12
             3.13
+          allow-prereleases: true
 
       - name: Setup uv
         uses: yezz123/setup-uv@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ classifiers = [
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
   "Programming Language :: Python",
   "Topic :: Software Development :: Quality Assurance",
   "Topic :: Software Development :: Libraries :: Python Modules",
@@ -89,6 +90,8 @@ installer = "uv"
 
 [tool.hatch.envs.hatch-test]
 features = ["test", "cli"]
+env-vars.PYTHONWARNDEFAULTENCODING = "1"
+
 
 [tool.hatch.envs.lint]
 dependencies = ["pre-commit"]
@@ -122,7 +125,7 @@ skip-install = true
 scripts.serve = "cd docs && echo 'Serving on http://localhost:8080' && python -m http.server 8080"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.12", "3.11", "3.10"]
+python = ["3.13", "3.12", "3.11", "3.10"]
 
 
 [tool.pytest.ini_options]

--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import itertools
 import json
+import os
 import sys
 import typing
 from collections.abc import Mapping, Sequence
@@ -83,6 +84,17 @@ def rich_printer(
     status: Status,
     header: str = "",
 ) -> None:
+    # Before Python 3.15, this isn't always unicode
+    if (
+        sys.version_info < (3, 15)
+        and "PYTHONIOENCODING" not in os.environ
+        and "PYTHONUTF8" not in os.environ
+    ):
+        if sys.stdout.encoding != "utf-8":
+            sys.stdout.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+        if sys.stderr.encoding != "utf-8":
+            sys.stderr.reconfigure(encoding="utf-8")  # type: ignore[union-attr]
+
     console = rich.console.Console(
         record=svg, quiet=svg, stderr=stderr, color_system="auto" if color else None
     )

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -28,7 +28,7 @@ def multiple_packages(tmp_path: Path) -> tuple[str, str]:
             """
         )
 
-        package.joinpath("pyproject.toml").write_text(basic_toml)
+        package.joinpath("pyproject.toml").write_text(basic_toml, encoding="utf-8")
         package.joinpath(".pre-commit-config.yaml").touch()
         package.joinpath("README.md").touch()
 

--- a/tests/test_package.py
+++ b/tests/test_package.py
@@ -36,7 +36,8 @@ def test_broken_validate_pyproject(tmp_path: Path) -> None:
                 [tool.repo-review]
                 ignore = ["a2"]
             """
-        )
+        ),
+        encoding="utf-8",
     )
 
     results = process(tmp_path)


### PR DESCRIPTION
Working on https://github.com/scientific-python/cookie/pull/474 (and therefore https://github.com/scientific-python/cookie/issues/473). I think I know how to fix it, but first trying to reproduce in CI. Like there, we were setting PYTHONUTF8, which likely hides the issue.
