### PR TITLE
chore: use 3.12 by default for action

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-review[dev]",
-  "image": "mcr.microsoft.com/devcontainers/python:0-3.11",
+  "image": "mcr.microsoft.com/devcontainers/python:0-3.12",
   "postCreateCommand": "pipx install hatch && pip install -e.[cli,test] pylint",
   "customizations": {
     "vscode": {

--- a/action.yml
+++ b/action.yml
@@ -26,7 +26,7 @@ runs:
     - uses: actions/setup-python@v5
       id: python
       with:
-        python-version: "3.11"
+        python-version: "3.12"
         update-environment: false
 
     - name: Install repo-review and plugins


### PR DESCRIPTION
Bump from 3.11.
