### PR TITLE
Fix spelling and grammar typos

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,7 @@ webapp. It also would allow `zipfile.Path` to work just as well, too - no need
 to extract.
 
 [Checks][] can request [fixtures][] (like [pytest][]) as arguments. Check files
-can add new fixtures as needed. Fixtures are are specified with entry points,
+can add new fixtures as needed. Fixtures are specified with entry points,
 and take any other fixture as arguments as well - the `root` and `package`
 fixtures represents the root of the repository and of the package you are
 checking, respectively, and are the basis for the other fixtures, which are
@@ -134,7 +134,7 @@ collection functions, the family entry-point also supports fixtures.
 This project inspired [Try-PyHF](https://kratsg.github.io/try-pyhf/), an
 interface for a High Energy Physics package in Scikit-HEP.
 
-This project inspired [abSENSE](https://princetonuniversity.github.io/abSENSE/), an
+This project inspired [abSENSE](https://princetonuniversity.github.io/abSENSE/), a
 web interface to abSENSE.
 
 This was developed for [Scikit-HEP][] before moving to Scientific-Python.

--- a/docs/checks.md
+++ b/docs/checks.md
@@ -30,7 +30,7 @@ explanation instead of the `check()` docstring, you can return a non-empty
 string from the check instead of `False`. Returning `None` makes a check
 "skipped". Docstrings/error messages can access their own object with `{self}`
 and check name with `{name}` (these are processed with `.format()`, so escape `{}`
-as `{{}}`). The error message is in markdown format.
+as `{{}}`). The error message is in Markdown format.
 
 ```{versionchanged} 0.9
 The string return value is not processed via `.format`. You can use `self` and

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -17,7 +17,7 @@ pass `--package-dir <path>`.
 
 There are four output formats; `rich` produces great terminal output, `svg`
 produces an SVG based on the rich output, `html` produces a custom HTML report,
-and `json` produces a output that can be processed easily. To make it easier to
+and `json` produces an output that can be processed easily. To make it easier to
 support tools like GitHub Actions, there is also a `--stderr FORMAT` output
 option that produces the selected format on stderr as well, and disables
 producing terminal escape codes on stdout, even if `FORCE_COLOR` is set. This

--- a/docs/families.md
+++ b/docs/families.md
@@ -15,7 +15,7 @@ class Family(typing.TypedDict, total=False):
 
 The `name` will be shown instead if given. The families will be sorted by
 `order` then key. And a `description` will be shown after the name if provided;
-it is expected to be in markdown format.
+it is expected to be in Markdown format.
 
 ```{versionadded} 0.9
 Descriptions are now supported.
@@ -24,7 +24,7 @@ Descriptions are now supported.
 Then you can provide a function that maps family strings to this extra information:
 
 ```python
-def get_familes() -> dict[str, Family]:
+def get_families() -> dict[str, Family]:
     return {
         "general": Family(
             name="General",

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -15,7 +15,7 @@ to use it is:
 pipx run <plugin-name>[cli] .
 ```
 
-This uses [pipx][] (pip for executables) to download the plugin and all of it's
+This uses [pipx][] (pip for executables) to download the plugin and all of its
 dependencies (including repo-review itself) into a temporary virtual
 environment (cached for a week), then runs it. For example:
 


### PR DESCRIPTION
Found while reading the documentation.

* `get_familes()` -> `get_families()`
* `it's` -> `its`
* `markdown` -> `Markdown`
* Duplicated word
* "a/an" agreements

I also ran [`typos`](https://github.com/crate-ci/typos) and [codespell](https://github.com/codespell-project/codespell) against the entire repo and they found no other issues.
