### PR TITLE
Use `ansi_light` for syntax highlighting

### DIFF
--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -36,7 +36,7 @@ from .processor import Result, as_simple_dict, collect_all, process
 
 __all__ = ["main", "Formats", "Show", "Status"]
 
-CODE_THEME = "default"
+CODE_THEME = "ansi_light"
 
 
 def __dir__() -> list[str]:


### PR DESCRIPTION
This eliminates a bright white background color that renders for Markdown code blocks.

This change was tested on light and dark terminal backgrounds and does not force a background color in either case.

Fixes #249

----

## Example: Solarized light

> ![image](https://github.com/user-attachments/assets/e7a3f5ad-39cf-4ee1-bc10-d0943809bd99)

## Example: Solarized dark

> ![image](https://github.com/user-attachments/assets/1a2b20a5-9500-41a4-a276-9395e3077940)

