### PR TITLE
chore: better integration with uv run

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -32,23 +32,17 @@ $ hatch run example:repo-review <args> # Run an example
 Hatch handles everything for you, including setting up an temporary virtual
 environment.
 
+Using `uv run` directly is also supported.
+
 ## Setting up a development environment manually
 
-You can set up a development environment by running:
+You can set up a development environment in `.venv` by running:
 
 ```bash
-python3 -m venv .venv
-source ./.venv/bin/activate
-pip install -v -e .[dev]
+uv sync
 ```
 
-If you have the [Python Launcher for Unix](https://github.com/brettcannon/python-launcher),
-you can instead do:
-
-```bash
-py -m venv .venv
-py -m install -v -e .[dev]
-```
+Or just prefix every command by `uv run`.
 
 # Post setup
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,17 +8,17 @@ repos:
     rev: 1.19.1
     hooks:
       - id: blacken-docs
-        additional_dependencies: [black==23.*]
+        additional_dependencies: [black==24.*]
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: "v0.8.1"
+    rev: "v0.8.3"
     hooks:
       - id: ruff
         args: ["--fix", "--show-fixes"]
       - id: ruff-format
 
   - repo: https://github.com/rbubley/mirrors-prettier
-    rev: "v3.4.1"
+    rev: "v3.4.2"
     hooks:
       - id: prettier
         types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -13,6 +13,4 @@ build:
     - asdf plugin add uv
     - asdf install uv latest
     - asdf global uv latest
-    - uv venv
-    - uv pip install .[docs]
-    - . .venv/bin/activate && sphinx-build -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html
+    - uv run --group docs sphinx-build -T -b html -d docs/_build/doctrees -D language=en docs $READTHEDOCS_OUTPUT/html

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -37,32 +37,6 @@ dependencies = [
   "typing-extensions; python_version < '3.11'",
 ]
 
-[project.optional-dependencies]
-cli = [
-  "click >=8",
-  "rich >=12.2",
-  "rich-click",
-]
-test = [
-  "pytest >=7",
-  "sp-repo-review >=2024.08.19",
-  "validate-pyproject >=0.14",
-]
-dev = [
-  "repo-review[test,cli]",
-]
-docs = [
-  "furo",
-  "myst_parser >=0.13",
-  "repo-review[cli]",
-  "sphinx >=4.0",
-  "sphinx-autodoc-typehints",
-  "sphinx-copybutton",
-  "sphinxcontrib-programoutput",
-  "sphinxext-opengraph",
-  "sphinx-github-changelog",
-]
-
 [project.urls]
 Changelog = "https://github.com/scientific-python/repo-review/releases"
 Demo = "https://scientific-python.github.io/repo-review"
@@ -80,6 +54,35 @@ list_all = "repo_review.fixtures:list_all"
 [project.entry-points."validate_pyproject.tool_schema"]
 repo-review = "repo_review.schema:get_schema"
 
+[project.optional-dependencies]
+cli = [
+  "click >=8",
+  "rich >=12.2",
+  "rich-click",
+]
+
+[dependency-groups]
+test = [
+  "pytest >=7",
+  "sp-repo-review >=2024.08.19",
+  "validate-pyproject >=0.14",
+]
+dev = [
+  { include-group = "test" },
+  "sp-repo-review[cli]",
+  "validate-pyproject-schema-store[all]",
+]
+docs = [
+  "furo",
+  "myst_parser >=0.13",
+  "repo-review[cli]",
+  "sphinx >=4.0",
+  "sphinx-autodoc-typehints",
+  "sphinx-copybutton",
+  "sphinxcontrib-programoutput",
+  "sphinxext-opengraph",
+  "sphinx-github-changelog",
+]
 
 [tool.hatch]
 version.source = "vcs"
@@ -89,7 +92,13 @@ build.hooks.vcs.version-file = "src/repo_review/_version.py"
 installer = "uv"
 
 [tool.hatch.envs.hatch-test]
-features = ["test", "cli"]
+features = ["cli"]
+# duplicated since hatch doesn't support groups yet
+dependencies = [
+  "pytest >=7",
+  "sp-repo-review >=2024.08.19",
+  "validate-pyproject >=0.14",
+]
 env-vars.PYTHONWARNDEFAULTENCODING = "1"
 
 [tool.hatch.envs.lint]
@@ -103,8 +112,19 @@ dependencies = ["pylint>=3.2"]
 scripts.lint = "pylint repo_review {args}"
 
 [tool.hatch.envs.docs]
-features = ["docs"]
-dependencies = ["sphinx-autobuild"]
+# duplicated since hatch doesn't support groups yet
+dependencies = [
+  "furo",
+  "myst_parser >=0.13",
+  "repo-review[cli]",
+  "sphinx >=4.0",
+  "sphinx-autodoc-typehints",
+  "sphinx-copybutton",
+  "sphinxcontrib-programoutput",
+  "sphinxext-opengraph",
+  "sphinx-github-changelog",
+  "sphinx-autobuild",
+]
 scripts.linkcheck = "sphinx-build -b=linkcheck docs docs/_build/linkcheck {args}"
 scripts.html = "sphinx-build --keep-going -n -T -b=html docs docs/_build/html {args}"
 scripts.serve = "sphinx-autobuild -n -T -b=html docs docs/_build/html {args}"


### PR DESCRIPTION
`uv run` works. Some duplication due to Hatch not supporting PEP 735.
