### PR TITLE
feat(cli): extend pyproject lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ ignore = ["A100"]
 ```
 
 If `--select` or `--ignore` are given on the command line, they will override
-the `pyproject.toml` config.
+the `pyproject.toml` config. You can use `--extend-select` and `--extend-ignore`
+on the command line to extend the `pyproject.toml` config. These CLI options
+are comma separated.
 
 ## Comparison to other frameworks
 

--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -316,6 +316,16 @@ def _remote_path_processor(package: Path) -> Path | GHPath:
     default="",
 )
 @click.option(
+    "--extend-select",
+    help="Checks to run in addition to the ones selected.",
+    default="",
+)
+@click.option(
+    "--extend-ignore",
+    help="Checks to ignore in addition to the ones ignored.",
+    default="",
+)
+@click.option(
     "--package-dir",
     "-p",
     help="Path to python package.",
@@ -327,6 +337,8 @@ def main(
     stderr_fmt: Formats | None,
     select: str,
     ignore: str,
+    extend_select: str,
+    extend_ignore: str,
     package_dir: str,
     show: Show,
 ) -> None:
@@ -351,6 +363,8 @@ def main(
             stderr_fmt,
             select,
             ignore,
+            extend_select,
+            extend_ignore,
             package_dir,
             add_header=len(packages) > 1,
             show=show,
@@ -378,6 +392,8 @@ def on_each(
     stderr_fmt: Literal["rich", "json", "html", "svg"] | None,
     select: str,
     ignore: str,
+    extend_select: str,
+    extend_ignore: str,
     package_dir: str,
     *,
     add_header: bool,
@@ -387,6 +403,8 @@ def on_each(
 
     ignore_list = {x.strip() for x in ignore.split(",") if x}
     select_list = {x.strip() for x in select.split(",") if x}
+    extend_ignore_list = {x.strip() for x in extend_ignore.split(",") if x}
+    extend_select_list = {x.strip() for x in extend_select.split(",") if x}
 
     collected = collect_all(package, subdir=package_dir)
     if len(collected.checks) == 0:
@@ -407,7 +425,12 @@ def on_each(
         header = package.name
 
     families, processed = process(
-        base_package, select=select_list, ignore=ignore_list, subdir=package_dir
+        base_package,
+        select=select_list,
+        ignore=ignore_list,
+        extend_select=extend_select_list,
+        extend_ignore=extend_ignore_list,
+        subdir=package_dir,
     )
 
     status: Status = "passed" if processed else "empty"

--- a/src/repo_review/processor.py
+++ b/src/repo_review/processor.py
@@ -179,6 +179,8 @@ def process(
     *,
     select: Set[str] = frozenset(),
     ignore: Set[str] = frozenset(),
+    extend_select: Set[str] = frozenset(),
+    extend_ignore: Set[str] = frozenset(),
     subdir: str = "",
 ) -> ProcessReturn:
     """
@@ -199,8 +201,12 @@ def process(
 
     # Collect our own config
     config = pyproject(package).get("tool", {}).get("repo-review", {})
-    select_checks = select if select else frozenset(config.get("select", ()))
-    skip_checks = ignore if ignore else frozenset(config.get("ignore", ()))
+    select_checks = (
+        select if select else frozenset(config.get("select", ())) | extend_select
+    )
+    skip_checks = (
+        ignore if ignore else frozenset(config.get("ignore", ())) | extend_ignore
+    )
 
     # Make a graph of the check's interdependencies
     graph: dict[str, Set[str]] = {


### PR DESCRIPTION
Add `--extend-*` options to not override pyproject.toml config.
