### PR TITLE
feat: support reasons for ignores

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,8 @@ select = ["A", "B", "C100"]
 ignore = ["A100"]
 ```
 
+The ignore list can also be a table, with reasons for values.
+
 If `--select` or `--ignore` are given on the command line, they will override
 the `pyproject.toml` config. You can use `--extend-select` and `--extend-ignore`
 on the command line to extend the `pyproject.toml` config. These CLI options

--- a/docs/intro.md
+++ b/docs/intro.md
@@ -51,9 +51,25 @@ You can explicitly list checks to select or skip in your `pyproject.toml`:
 
 ```toml
 [tool.repo-review]
-select = ["..."]
-ignore = ["..."]
+select = ["A", "B", "C100"]
+ignore = ["A100"]
 ```
+
+You can list the letter prefix or the exact check name. The ignore list can also
+be a table, with reasons for values. These will be shown explicitly in the report if
+a reason is given.
+
+```toml
+[tool.repo-review.ignore]
+A = "Skipping this whole family"
+B101 = "Skipping this specific check"
+C101 = ""  # Hidden from report, like a normal ignore
+```
+
+If `--select` or `--ignore` are given on the command line, they will override
+the `pyproject.toml` config. You can use `--extend-select` and `--extend-ignore`
+on the command line to extend the `pyproject.toml` config. These CLI options
+are comma separated.
 
 ## Pre-commit
 

--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -163,6 +163,13 @@ def rich_printer(
             msg.append(rich.text.Text.from_markup(description, style=style))
             if result.result is None:
                 msg.append(" [skipped]", style="yellow bold")
+                if result.skip_reason:
+                    sr_style = "yellow"
+                    msg.append(" (", style=sr_style)
+                    msg.append(
+                        rich.text.Text.from_markup(result.skip_reason, style=sr_style)
+                    )
+                    msg.append(")", style=sr_style)
                 tree.add(msg)
             elif result.result:
                 msg.append(rich.text.Text.from_markup(" :white_check_mark:"))

--- a/src/repo_review/html.py
+++ b/src/repo_review/html.py
@@ -61,7 +61,7 @@ def to_html(
                 else "red"
             )
             icon = (
-                "&#9888;&#65039;"
+                ("&#128311;" if result.skip_reason else "&#9888;&#65039;")
                 if result.result is None
                 else "&#9989;"
                 if result.result
@@ -79,6 +79,11 @@ def to_html(
                 if result.url
                 else result.description
             )
+            if result.skip_reason:
+                description += (
+                    f'<br/><span style="color:DarkKhaki;"><b>Skipped:</b> '
+                    f"<em>{md.render(result.skip_reason)}</em></span>"
+                )
             print(f'<tr style="color: {color};">')
             print(f'<td><span role="img" aria-label="{result_txt}">{icon}</span></td>')
             print(f'<td nowrap="nowrap">{result.name}</td>')

--- a/tests/test_self.py
+++ b/tests/test_self.py
@@ -11,7 +11,9 @@ def patch_entry_points(local_entry_points: object) -> None:
 
 
 def test_pyproject() -> None:
-    families, results = repo_review.processor.process(Path())
+    families, results = repo_review.processor.process(
+        Path(), extend_ignore={"X", "PP303"}
+    )
 
     assert families == {
         "general": {},
@@ -26,7 +28,9 @@ def test_pyproject() -> None:
 
 
 def test_no_pyproject() -> None:
-    families, results = repo_review.processor.process(Path("tests"))
+    families, results = repo_review.processor.process(
+        Path("tests"), extend_ignore={"X", "PP303"}
+    )
 
     assert families == {
         "general": {},
@@ -58,12 +62,13 @@ def test_empty_pyproject() -> None:
             "description": "Has flit_core.buildapi backend",
             "name": "PyProject",
         },
+        "skipped": {},
     }
-    assert len(results) == 9
+    assert len(results) == 12
 
     assert (
         sum(result.result is None for result in results if result.family == "pyproject")
-        == 1
+        == 2
     )
     assert (
         sum(result.result for result in results if isinstance(result.result, bool)) == 6
@@ -72,3 +77,6 @@ def test_empty_pyproject() -> None:
         sum(result.result is None for result in results if result.family == "general")
         == 0
     )
+    assert sum(1 for result in results if result.skip_reason) == 3
+    assert sum(1 for result in results if result.skip_reason == "One skip") == 1
+    assert sum(1 for result in results if result.skip_reason == "Group skip") == 2

--- a/tests/test_utilities/pyproject.py
+++ b/tests/test_utilities/pyproject.py
@@ -142,10 +142,51 @@ class PP302(PyProject):
         return "minversion" in options and float(options["minversion"]) >= 6
 
 
-def repo_review_checks() -> dict[str, PyProject | General]:
-    return {p.__name__: p() for p in PyProject.__subclasses__()} | {
+class PP999(PyProject):
+    "Skipped check (single)"
+
+    @staticmethod
+    def check() -> bool:
+        "Not used"
+        return False
+
+
+class X101:
+    "Skipped check (multi)"
+
+    family = "skipped"
+
+    @staticmethod
+    def check() -> bool:
+        "Not used"
+        return False
+
+
+class X102:
+    "Skipped check (multi)"
+
+    family = "skipped"
+
+    @staticmethod
+    def check() -> bool:
+        "Not used"
+        return False
+
+
+def repo_review_checks(
+    pyproject: dict[str, Any],
+) -> dict[str, PyProject | General | X101 | X102]:
+    ret = {p.__name__: p() for p in PyProject.__subclasses__()} | {
         p.__name__: p() for p in General.__subclasses__()
     }
+    extra_checks = (
+        pyproject.get("tool", {}).get("repo-review-local", {}).get("extra", False)
+    )
+    return (
+        (ret | {"X101": X101()} | {"X102": X102()})
+        if extra_checks
+        else {k: v for k, v in ret.items() if k != "PP999"}
+    )
 
 
 def repo_review_families(pyproject: dict[str, Any]) -> dict[str, dict[str, str]]:

--- a/tests/test_utilities/pyproject.toml
+++ b/tests/test_utilities/pyproject.toml
@@ -16,3 +16,11 @@ pyproject = "pyproject:repo_review_checks"
 pyproject = "pyproject:repo_review_families"
 
 [tool.example]
+
+
+[tool.repo-review.ignore]
+"PP999" = "One skip"
+"X" = "Group skip"
+
+[tool.repo-review-local]
+extra = true


### PR DESCRIPTION
Fix #216. If something is skipped with a description, it will be shown with the reason. It's a new field (usually blank) for json, and is added to HTML and terminal outputs.


<h3>Documentation</h3>
<table>
<tr><th>?</th><th nowrap="nowrap">Name</th><th>Description</th></tr>
<tr style="color: green;">
<td><span role="img" aria-label="Passed">&#9989;</span></td>
<td nowrap="nowrap">RTD100</td>
<td><a href="https://learn.scientific-python.org/development/guides/docs#RTD100">Uses ReadTheDocs (pyproject config)</a></td>
</tr>
<tr style="color: green;">
<td><span role="img" aria-label="Passed">&#9989;</span></td>
<td nowrap="nowrap">RTD101</td>
<td><a href="https://learn.scientific-python.org/development/guides/docs#RTD101">You have to set the RTD version number to 2</a></td>
</tr>
<tr style="color: green;">
<td><span role="img" aria-label="Passed">&#9989;</span></td>
<td nowrap="nowrap">RTD102</td>
<td><a href="https://learn.scientific-python.org/development/guides/docs#RTD102">You have to set the RTD build image</a></td>
</tr>
<tr style="color: orange;">
<td><span role="img" aria-label="Skipped">&#128311;</span></td>
<td nowrap="nowrap">RTD103</td>
<td><a href="https://learn.scientific-python.org/development/guides/docs#RTD103">You have to set the RTD python version</a><br/><span style="color:DarkKhaki;"><b>Skipped:</b> <em><p>Using Ruby instead of Python for docs</p>
</em></span></td>
</tr>
</table>


![Screenshot 2025-02-04 at 5 08 46 PM](https://github.com/user-attachments/assets/0734b7ab-6cab-460a-b8d7-555d1e13f7eb)

