### PR TITLE
fix: webapp support 0.12's skip reasons, add md_as_html method

### DIFF
--- a/docs/index.html
+++ b/docs/index.html
@@ -64,9 +64,9 @@
         <App
           header={true}
           deps={[
-            "repo-review~=0.11.3",
+            "repo-review~=0.12.0",
             "sp-repo-review==2025.01.22",
-            "validate-pyproject-schema-store==2025.01.20",
+            "validate-pyproject-schema-store==2025.02.03",
             "validate-pyproject[all]~=0.22.0",
           ]}
         />,

--- a/docs/webapp.js
+++ b/docs/webapp.js
@@ -93,7 +93,7 @@ function Results(props) {
           variant="body2"
           color="text.disabled"
         >
-          {` [skipped] ${result.skip_reason}` }
+          {` [skipped] ${result.skip_reason}`}
         </MaterialUI.Typography>
       );
       const msg = (

--- a/docs/webapp.js
+++ b/docs/webapp.js
@@ -232,15 +232,17 @@ class App extends React.Component {
         families_checks = pyodide.runPython(`
           from repo_review.processor import process, md_as_html
           from repo_review.ghpath import GHPath
+          from dataclasses import replace
 
           package = GHPath(repo="${state.repo}", branch="${state.branch}")
-          result = process(package)
+          families, checks = process(package)
 
-          for v in result[0].values():
+          for v in families.values():
               if v.get("description"):
                   v["description"] = md_as_html(v["description"])
+          checks = [replace(v, err_msg=md_as_html(v.err_msg), skip_reason=md_as_html(v.skip_reason)) for v in checks]
 
-          result
+          (families, checks)
           `);
       } catch (e) {
         if (e.message.includes("KeyError: 'tree'")) {
@@ -277,7 +279,7 @@ class App extends React.Component {
           name: val.name.toString(),
           description: val.description.toString(),
           state: val.result,
-          err_msg: val.err_as_html().toString(),
+          err_msg: val.err_msg.toString(),
           url: val.url.toString(),
           skip_reason: val.skip_reason.toString(),
         });

--- a/docs/webapp.js
+++ b/docs/webapp.js
@@ -93,7 +93,7 @@ function Results(props) {
           variant="body2"
           color="text.disabled"
         >
-          {" [skipped]"}
+          {` [skipped] ${result.skip_reason}` }
         </MaterialUI.Typography>
       );
       const msg = (
@@ -200,6 +200,7 @@ class App extends React.Component {
       msg: `<p>${DEFAULT_MSG}</p><h4>Packages:</h4> ${deps_str}`,
       progress: false,
       err_msg: "",
+      skip_reason: "",
       url: "",
     };
     this.pyodide_promise = prepare_pyodide(props.deps);
@@ -278,6 +279,7 @@ class App extends React.Component {
           state: val.result,
           err_msg: val.err_as_html().toString(),
           url: val.url.toString(),
+          skip_reason: val.skip_reason.toString(),
         });
       }
 

--- a/src/repo_review/html.py
+++ b/src/repo_review/html.py
@@ -6,10 +6,8 @@ import io
 import typing
 from collections.abc import Mapping, Sequence
 
-import markdown_it
-
 from .families import Family, get_family_description, get_family_name
-from .processor import Result
+from .processor import Result, md_as_html
 
 if typing.TYPE_CHECKING:
     from .__main__ import Status
@@ -37,16 +35,15 @@ def to_html(
     """
     out = io.StringIO()
     print = functools.partial(builtins.print, file=out)
-    md = markdown_it.MarkdownIt()
 
     for family in families:
         family_name = get_family_name(families, family)
         family_description = get_family_description(families, family)
-        family_results = [r for r in processed if r.family == family]
+        family_results = [r.md_as_html() for r in processed if r.family == family]
         if family_results or family_description:
             print(f"<h3>{family_name}</h3>")
         if family_description:
-            print(md.render(family_description).strip())
+            print("<p>", md_as_html(family_description), "</p>")
         if family_results:
             print("<table>")
             print(
@@ -82,7 +79,7 @@ def to_html(
             if result.skip_reason:
                 description += (
                     f'<br/><span style="color:DarkKhaki;"><b>Skipped:</b> '
-                    f"<em>{md.render(result.skip_reason)}</em></span>"
+                    f"<em>{result.skip_reason}</em></span>"
                 )
             print(f'<tr style="color: {color};">')
             print(f'<td><span role="img" aria-label="{result_txt}">{icon}</span></td>')
@@ -93,7 +90,7 @@ def to_html(
                 print("<td>")
                 print(description)
                 print("<br/>")
-                print(md.render(result.err_msg))
+                print(result.err_msg)
                 print("</td>")
             print("</tr>")
         if family_results:

--- a/src/repo_review/processor.py
+++ b/src/repo_review/processor.py
@@ -3,11 +3,12 @@ from __future__ import annotations
 import copy
 import dataclasses
 import graphlib
+import sys
 import textwrap
 import typing
 import warnings
 from collections.abc import Mapping, Set
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 import markdown_it
 
@@ -23,6 +24,12 @@ from .checks import (
 from .families import Family, collect_families
 from .fixtures import apply_fixtures, collect_fixtures, compute_fixtures, pyproject
 from .ghpath import EmptyTraversable
+
+if TYPE_CHECKING:
+    if sys.version_info >= (3, 11):
+        from typing import Self
+    else:
+        from typing_extensions import Self
 
 __all__ = [
     "CollectionReturn",
@@ -84,8 +91,21 @@ class Result:
     def err_as_html(self) -> str:
         """
         Produces HTML from the error message, assuming it is in markdown.
+        Deprecated, use :meth:`md_as_html` directly instead.
         """
         return md_as_html(self.err_msg)
+
+    def md_as_html(self) -> Self:
+        """
+        Process fields that are assumed to be markdown.
+
+        .. versionadded:: 0.12.1
+        """
+        return dataclasses.replace(
+            self,
+            err_msg=md_as_html(self.err_msg),
+            skip_reason=md_as_html(self.skip_reason),
+        )
 
 
 class ProcessReturn(typing.NamedTuple):


### PR DESCRIPTION
Now that 0.12 is on PyPI, support can be added here.
