### PR TITLE
chore: bump to Pyodide version 0.27.3 and update dependencies

### DIFF
--- a/docs/api/repo_review.resources.rst
+++ b/docs/api/repo_review.resources.rst
@@ -3,5 +3,5 @@ repo\_review.resources package
 
 .. automodule:: repo_review.resources
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/api/repo_review.rst
+++ b/docs/api/repo_review.rst
@@ -3,8 +3,8 @@ repo\_review package
 
 .. automodule:: repo_review
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -22,61 +22,61 @@ repo\_review.checks module
 
 .. automodule:: repo_review.checks
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.families module
 ----------------------------
 
 .. automodule:: repo_review.families
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.fixtures module
 ----------------------------
 
 .. automodule:: repo_review.fixtures
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.ghpath module
 --------------------------
 
 .. automodule:: repo_review.ghpath
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.html module
 ------------------------
 
 .. automodule:: repo_review.html
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.processor module
 -----------------------------
 
 .. automodule:: repo_review.processor
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.schema module
 --------------------------
 
 .. automodule:: repo_review.schema
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.testing module
 ---------------------------
 
 .. automodule:: repo_review.testing
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
       content="initial-scale=1, width=device-width"
     />
     <script
-      src="https://cdn.jsdelivr.net/pyodide/v0.27.1/full/pyodide.js"
+      src="https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide.js"
       crossorigin
     ></script>
     <!-- Production -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,7 +66,7 @@
           deps={[
             "repo-review~=0.12.1",
             "sp-repo-review==2025.01.22",
-            "validate-pyproject[all]~=0.22.0",
+            "validate-pyproject[all]~=0.23.0",
             "validate-pyproject-schema-store==2025.2.24",
           ]}
         />,

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,8 +66,8 @@
           deps={[
             "repo-review~=0.12.1",
             "sp-repo-review==2025.01.22",
-            "validate-pyproject-schema-store==2025.02.03",
             "validate-pyproject[all]~=0.22.0",
+            "validate-pyproject-schema-store==2025.2.24",
           ]}
         />,
       );


### PR DESCRIPTION
## Description

This pull request updates Pyodide to version 0.27.3 that we released today (https://pyodide.org/en/stable/project/changelog.html#version-0-27-3). It does not have much to note except a few new packages and that iOS support that was broken since 0.27.1 (which has been restored now).

Also, judging from https://github.com/henryiii/validate-pyproject-schema-store/releases and https://validate-pyproject.readthedocs.io/en/latest/changelog.html, I don't think there is any major breakage to worry about.

## Changes made

- Updated Pyodide to version 0.27.3
- Updated ``validate-pyproject`` to version 0.23.0
- Updated ``validate-pyproject-schema-store`` to version 2025.2.24

