### PR TITLE
feat: [web app] support both branches and tags in the reference selector

### DIFF
--- a/docs/api/repo_review.resources.rst
+++ b/docs/api/repo_review.resources.rst
@@ -3,5 +3,5 @@ repo\_review.resources package
 
 .. automodule:: repo_review.resources
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/api/repo_review.rst
+++ b/docs/api/repo_review.rst
@@ -3,8 +3,8 @@ repo\_review package
 
 .. automodule:: repo_review
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 Subpackages
 -----------
@@ -22,61 +22,61 @@ repo\_review.checks module
 
 .. automodule:: repo_review.checks
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.families module
 ----------------------------
 
 .. automodule:: repo_review.families
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.fixtures module
 ----------------------------
 
 .. automodule:: repo_review.fixtures
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.ghpath module
 --------------------------
 
 .. automodule:: repo_review.ghpath
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.html module
 ------------------------
 
 .. automodule:: repo_review.html
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.processor module
 -----------------------------
 
 .. automodule:: repo_review.processor
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.schema module
 --------------------------
 
 .. automodule:: repo_review.schema
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:
 
 repo\_review.testing module
 ---------------------------
 
 .. automodule:: repo_review.testing
    :members:
-   :undoc-members:
    :show-inheritance:
+   :undoc-members:

--- a/docs/index.html
+++ b/docs/index.html
@@ -6,7 +6,7 @@
       content="initial-scale=1, width=device-width"
     />
     <script
-      src="https://cdn.jsdelivr.net/pyodide/v0.27.1/full/pyodide.js"
+      src="https://cdn.jsdelivr.net/pyodide/v0.27.3/full/pyodide.js"
       crossorigin
     ></script>
     <!-- Production -->

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,7 +66,7 @@
           deps={[
             "repo-review~=0.12.1",
             "sp-repo-review==2025.01.22",
-            "validate-pyproject[all]~=0.22.0",
+            "validate-pyproject[all]~=0.23.0",
             "validate-pyproject-schema-store==2025.2.24",
           ]}
         />,

--- a/docs/index.html
+++ b/docs/index.html
@@ -66,8 +66,8 @@
           deps={[
             "repo-review~=0.12.1",
             "sp-repo-review==2025.01.22",
-            "validate-pyproject-schema-store==2025.02.03",
             "validate-pyproject[all]~=0.22.0",
+            "validate-pyproject-schema-store==2025.2.24",
           ]}
         />,
       );

--- a/docs/webapp.js
+++ b/docs/webapp.js
@@ -1,5 +1,5 @@
 const DEFAULT_MSG =
-  "Enter a GitHub repo and branch to review. Runs Python entirely in your browser using WebAssembly. Built with React, MaterialUI, and Pyodide.";
+  "Enter a GitHub repo and branch/tag to review. Runs Python entirely in your browser using WebAssembly. Built with React, MaterialUI, and Pyodide.";
 
 const urlParams = new URLSearchParams(window.location.search);
 const baseurl = window.location.pathname;
@@ -249,7 +249,7 @@ class App extends React.Component {
           this.setState({
             msg: DEFAULT_MSG,
             progress: false,
-            err_msg: "Invalid repository or branch. Please try again.",
+            err_msg: "Invalid repository or branch/tag. Please try again.",
           });
           return;
         }
@@ -345,7 +345,7 @@ class App extends React.Component {
               renderInput={(params) => (
                 <MaterialUI.TextField
                   {...params}
-                  label="Branch"
+                  label="Branch/Tag"
                   variant="outlined"
                   helperText="e.g. main"
                   sx={{ flexGrow: 2, minWidth: 130 }}

--- a/docs/webapp.js
+++ b/docs/webapp.js
@@ -154,6 +154,39 @@ function Results(props) {
   );
 }
 
+async function fetchRepoRefs(repo) {
+  if (!repo) return { branches: [], tags: [] };
+  try {
+    // Fetch both branches and tags from GitHub API
+    const [branchesResponse, tagsResponse] = await Promise.all([
+      fetch(`https://api.github.com/repos/${repo}/branches`),
+      fetch(`https://api.github.com/repos/${repo}/tags`),
+    ]);
+
+    if (!branchesResponse.ok || !tagsResponse.ok) {
+      console.error("Error fetching repo data");
+      return { branches: [], tags: [] };
+    }
+
+    const branches = await branchesResponse.json();
+    const tags = await tagsResponse.json();
+
+    return {
+      branches: branches.map((branch) => ({
+        name: branch.name,
+        type: "branch",
+      })),
+      tags: tags.map((tag) => ({
+        name: tag.name,
+        type: "tag",
+      })),
+    };
+  } catch (error) {
+    console.error("Error fetching repo references:", error);
+    return { branches: [], tags: [] };
+  }
+}
+
 async function prepare_pyodide(deps) {
   const deps_str = deps.map((i) => `"${i}"`).join(", ");
   const pyodide = await loadPyodide();
@@ -196,28 +229,58 @@ class App extends React.Component {
     this.state = {
       results: [],
       repo: urlParams.get("repo") || "",
-      branch: urlParams.get("branch") || "",
+      ref: urlParams.get("ref") || "",
+      refType: urlParams.get("refType") || "branch",
+      refs: { branches: [], tags: [] },
       msg: `<p>${DEFAULT_MSG}</p><h4>Packages:</h4> ${deps_str}`,
       progress: false,
+      loadingRefs: false,
       err_msg: "",
       skip_reason: "",
       url: "",
     };
     this.pyodide_promise = prepare_pyodide(props.deps);
+    this.refInputDebounce = null;
+  }
+
+  async fetchRepoReferences(repo) {
+    if (!repo) return;
+
+    this.setState({ loadingRefs: true });
+    const refs = await fetchRepoRefs(repo);
+    this.setState({
+      refs: refs,
+      loadingRefs: false,
+    });
+  }
+
+  handleRepoChange(repo) {
+    this.setState({ repo });
+
+    // debounce the API call to avoid too many requests
+    clearTimeout(this.refInputDebounce);
+    this.refInputDebounce = setTimeout(() => {
+      this.fetchRepoReferences(repo);
+    }, 500);
+  }
+
+  handleRefChange(ref, refType) {
+    this.setState({ ref, refType });
   }
 
   handleCompute() {
-    if (!this.state.repo || !this.state.branch) {
+    if (!this.state.repo || !this.state.ref) {
       this.setState({ results: [], msg: DEFAULT_MSG });
       window.history.replaceState(null, "", baseurl);
       alert(
-        `Please enter a repo (${this.state.repo}) and branch (${this.state.branch})`,
+        `Please enter a repo (${this.state.repo}) and branch/tag (${this.state.ref})`,
       );
       return;
     }
     const local_params = new URLSearchParams({
       repo: this.state.repo,
-      branch: this.state.branch,
+      ref: this.state.ref,
+      refType: this.state.refType,
     });
     window.history.replaceState(null, "", `${baseurl}?${local_params}`);
     this.setState({
@@ -234,7 +297,7 @@ class App extends React.Component {
           from repo_review.ghpath import GHPath
           from dataclasses import replace
 
-          package = GHPath(repo="${state.repo}", branch="${state.branch}")
+          package = GHPath(repo="${state.repo}", branch="${state.ref}")
           families, checks = process(package)
 
           for v in families.values():
@@ -288,7 +351,7 @@ class App extends React.Component {
       this.setState({
         results: results,
         families: families,
-        msg: `Results for ${state.repo}@${state.branch}`,
+        msg: `Results for ${state.repo}@${state.ref} (${state.refType})`,
         progress: false,
         err_msg: "",
         url: "",
@@ -300,13 +363,40 @@ class App extends React.Component {
   }
 
   componentDidMount() {
-    if (urlParams.get("repo") && urlParams.get("branch")) {
-      this.handleCompute();
+    if (urlParams.get("repo")) {
+      this.fetchRepoReferences(urlParams.get("repo"));
+
+      if (urlParams.get("ref")) {
+        this.handleCompute();
+      }
     }
   }
 
   render() {
-    const common_branches = ["main", "master", "develop", "stable"];
+    const refOptions = [
+      ...this.state.refs.branches.map((branch) => ({
+        label: `${branch.name} (branch)`,
+        value: branch.name,
+        type: "branch",
+      })),
+      ...this.state.refs.tags.map((tag) => ({
+        label: `${tag.name} (tag)`,
+        value: tag.name,
+        type: "tag",
+      })),
+    ];
+
+    // some common references for quick access if the API fails.
+    // this is only a fallback for backwards behaviour.
+    const commonRefs = [
+      { label: "main (branch)", value: "main", type: "branch" },
+      { label: "master (branch)", value: "master", type: "branch" },
+      { label: "develop (branch)", value: "develop", type: "branch" },
+      { label: "stable (branch)", value: "stable", type: "branch" },
+    ];
+
+    const availableOptions = refOptions.length > 0 ? refOptions : commonRefs;
+
     return (
       <MyThemeProvider>
         <MaterialUI.CssBaseline />
@@ -326,29 +416,64 @@ class App extends React.Component {
               autoFocus={true}
               onKeyDown={(e) => {
                 if (e.keyCode === 13)
-                  document.getElementById("branch-select").focus();
+                  document.getElementById("ref-select").focus();
               }}
-              onInput={(e) => this.setState({ repo: e.target.value })}
+              onInput={(e) => this.handleRepoChange(e.target.value)}
               defaultValue={urlParams.get("repo")}
               sx={{ flexGrow: 3 }}
             />
             <MaterialUI.Autocomplete
               disablePortal
-              id="branch-select"
-              options={common_branches}
+              id="ref-select"
+              options={availableOptions}
+              loading={this.state.loadingRefs}
               freeSolo={true}
               onKeyDown={(e) => {
                 if (e.keyCode === 13) this.handleCompute();
               }}
-              onInputChange={(e, value) => this.setState({ branch: value })}
-              defaultValue={urlParams.get("branch")}
+              getOptionLabel={(option) =>
+                typeof option === "string" ? option : option.label
+              }
+              renderOption={(props, option) => (
+                <li {...props}>{option.label}</li>
+              )}
+              onInputChange={(e, value) => {
+                // If the user enters free text, treat it as a branch
+                if (typeof value === "string") {
+                  this.handleRefChange(value, "branch");
+                }
+              }}
+              onChange={(e, option) => {
+                if (option) {
+                  if (typeof option === "object") {
+                    this.handleRefChange(option.value, option.type);
+                  } else {
+                    this.handleRefChange(option, "branch");
+                  }
+                }
+              }}
+              defaultValue={urlParams.get("ref")}
               renderInput={(params) => (
                 <MaterialUI.TextField
                   {...params}
                   label="Branch/Tag"
                   variant="outlined"
-                  helperText="e.g. main"
-                  sx={{ flexGrow: 2, minWidth: 130 }}
+                  helperText="e.g. main or v1.0.0"
+                  sx={{ flexGrow: 2, minWidth: 200 }}
+                  InputProps={{
+                    ...params.InputProps,
+                    endAdornment: (
+                      <React.Fragment>
+                        {this.state.loadingRefs ? (
+                          <MaterialUI.CircularProgress
+                            color="inherit"
+                            size={20}
+                          />
+                        ) : null}
+                        {params.InputProps.endAdornment}
+                      </React.Fragment>
+                    ),
+                  }}
                 />
               )}
             />
@@ -358,7 +483,7 @@ class App extends React.Component {
               variant="contained"
               size="large"
               disabled={
-                this.state.progress || !this.state.repo || !this.state.branch
+                this.state.progress || !this.state.repo || !this.state.ref
               }
             >
               <MaterialUI.Icon>start</MaterialUI.Icon>


### PR DESCRIPTION
## Description

> [!TIP]
> This change has been made on top of the changes in #261, but is more or less separate from them.

This pull request adds support in the repo-review web app for both branches and tags as refs when selecting a GitHub repository to run the tool on.


## Changes made

- Added GitHub API integration to fetch both branches and tags for selected repositories
- The URL parameter handling has been modified to track the reference type. The branches are shown first in the autocomplete dropdown, and tags come later.
- A fallback has been included for common branches when API requests fail (`main`/`develop`/`stable`/etc.)