### PR TITLE
fix(web app): always show commonly-used branch names at the top

### DIFF
--- a/docs/webapp.js
+++ b/docs/webapp.js
@@ -373,19 +373,48 @@ class App extends React.Component {
   }
 
   render() {
-    const refOptions = [
-      ...this.state.refs.branches.map((branch) => ({
+    const priorityBranches = ["main", "master", "develop", "stable"];
+    const branchMap = new Map(
+      this.state.refs.branches.map((branch) => [branch.name, branch])
+    );
+
+    const prioritizedBranches = [];
+    const otherBranches = [];
+
+    priorityBranches.forEach((branchName) => {
+      if (branchMap.has(branchName)) {
+        prioritizedBranches.push({
+          label: `${branchName} (branch)`,
+          value: branchName,
+          type: "branch",
+        });
+        // Remove from map so it doesn't get added twice.
+        branchMap.delete(branchName);
+      }
+    });
+
+    branchMap.forEach((branch) => {
+      otherBranches.push({
         label: `${branch.name} (branch)`,
         value: branch.name,
         type: "branch",
-      })),
-      ...this.state.refs.tags.map((tag) => ({
-        label: `${tag.name} (tag)`,
-        value: tag.name,
-        type: "tag",
-      })),
-    ];
+      });
+    });
 
+    otherBranches.sort((a, b) => a.value.localeCompare(b.value));
+
+    const tagOptions = this.state.refs.tags.map((tag) => ({
+      label: `${tag.name} (tag)`,
+      value: tag.name,
+      type: "tag",
+    }));
+    tagOptions.sort((a, b) => a.value.localeCompare(b.value));
+    // Combine them all together.
+    const refOptions = [
+      ...prioritizedBranches,
+      ...otherBranches,
+      ...tagOptions,
+    ];
     // some common references for quick access if the API fails.
     // this is only a fallback for backwards behaviour.
     const commonRefs = [

--- a/docs/webapp.js
+++ b/docs/webapp.js
@@ -375,7 +375,7 @@ class App extends React.Component {
   render() {
     const priorityBranches = ["main", "master", "develop", "stable"];
     const branchMap = new Map(
-      this.state.refs.branches.map((branch) => [branch.name, branch])
+      this.state.refs.branches.map((branch) => [branch.name, branch]),
     );
 
     const prioritizedBranches = [];


### PR DESCRIPTION
## Description

As a follow-up PR to #262, this PR alters the repo-review web app; it sorts "main", "master", "develop", or "stable" branches in that order, whichever of them exist(s) and shows them before any other branches. Also, branches and tags show up in alphabetical order.