### PR TITLE
ci: run on Ubuntu/windows on 3.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,8 @@ jobs:
             3.11
             3.12
             3.13
+            3.13t
+            3.14
             3.14t
           allow-prereleases: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -49,7 +49,7 @@ jobs:
           persist-credentials: false
 
       # Last one is activated
-      # yaml circular import issue on 3.14t on ubuntu 
+      # yaml circular import issue on 3.14t on ubuntu
       - uses: actions/setup-python@v5
         with:
           python-version: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
           fetch-depth: 0
           persist-credentials: false
 
+      # Last one is activated
+      # yaml circular import issue on 3.14t on ubuntu 
       - uses: actions/setup-python@v5
         with:
           python-version: |
@@ -56,7 +58,6 @@ jobs:
             3.12
             3.13t
             3.14
-            3.14t
             3.13
           allow-prereleases: true
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,10 +54,10 @@ jobs:
             3.10
             3.11
             3.12
-            3.13
             3.13t
             3.14
             3.14t
+            3.13
           allow-prereleases: true
 
       - name: Setup uv

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,7 +56,6 @@ jobs:
             3.10
             3.11
             3.12
-            3.13t
             3.14
             3.13
           allow-prereleases: true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ skip-install = true
 scripts.serve = "cd docs && echo 'Serving on http://localhost:8080' && python -m http.server 8080"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.14t", "3.13", "3.12", "3.11", "3.10"]
+python = ["3.14t", "3.14", "3.13t", "3.13", "3.12", "3.11", "3.10"]
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ skip-install = true
 scripts.serve = "cd docs && echo 'Serving on http://localhost:8080' && python -m http.server 8080"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.14", "3.13t", "3.13", "3.12", "3.11", "3.10"]
+python = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ skip-install = true
 scripts.serve = "cd docs && echo 'Serving on http://localhost:8080' && python -m http.server 8080"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.14t", "3.14", "3.13t", "3.13", "3.12", "3.11", "3.10"]
+python = ["3.14", "3.13t", "3.13", "3.12", "3.11", "3.10"]
 
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,7 @@ skip-install = true
 scripts.serve = "cd docs && echo 'Serving on http://localhost:8080' && python -m http.server 8080"
 
 [[tool.hatch.envs.hatch-test.matrix]]
-python = ["3.14", "3.13", "3.12", "3.11", "3.10"]
+python = ["3.14t", "3.13", "3.12", "3.11", "3.10"]
 
 
 [tool.pytest.ini_options]


### PR DESCRIPTION
Hatch just needs to run from 3.13 or older.
