### PR TITLE
chore: require pytest 9+

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -209,11 +209,11 @@ The code is written in modern Python (3.10+) with an emphasis on clean, readable
 - **Build**: hatchling, hatch-vcs (for version from git)
 - **Runtime**: markdown-it-py, pyyaml, tomli (Python <3.11)
 - **CLI optional**: click>=8, rich>=12.2, rich-click
-- **Dev**: pytest>=7, sp-repo-review (for self-checking), validate-pyproject
+- **Dev**: pytest>=9, sp-repo-review (for self-checking), validate-pyproject
 
 ### Testing Notes
 
-- **pytest configuration**: See `[tool.pytest.ini_options]` in pyproject.toml
+- **pytest configuration**: See `[tool.pytest]` in pyproject.toml
 - **Test fixtures**: See tests/conftest.py for entry point mocking
 - **Integration tests**: Use tests/test_utilities/ as example plugin
 - **Coverage**: Use `hatch run cov:test` for coverage reports

--- a/.gitignore
+++ b/.gitignore
@@ -142,3 +142,4 @@ src/*/_version.py
 
 node_modules/
 /.vscode
+uv.lock

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,7 +64,7 @@ cli = [
 
 [dependency-groups]
 test = [
-  "pytest >=7",
+  "pytest >=9",
   "sp-repo-review >=2025.11.04",
   "validate-pyproject >=0.14",
 ]
@@ -135,10 +135,11 @@ scripts.serve = "cd docs && echo 'Serving on http://localhost:8080' && python -m
 python = ["3.14", "3.13", "3.12", "3.11", "3.10"]
 
 
-[tool.pytest.ini_options]
-minversion = "7.0"
-addopts = ["-ra", "--strict-markers", "--strict-config", "--import-mode=importlib"]
-xfail_strict = true
+
+[tool.pytest]
+minversion = "9.0"
+addopts = ["-ra", "--import-mode=importlib"]
+strict = true
 log_level = "INFO"
 filterwarnings = [
   "error",

--- a/tests/test_multi.py
+++ b/tests/test_multi.py
@@ -23,8 +23,8 @@ def multiple_packages(tmp_path: Path) -> tuple[str, str]:
             requires = ["somepackage"]
             build-backend="somebackend"
 
-            [tool.pytest.ini_options]
-            minversion = "6.0"
+            [tool.pytest]
+            minversion = "9.0"
             """
         )
 

--- a/tests/test_utilities/pyproject.py
+++ b/tests/test_utilities/pyproject.py
@@ -114,30 +114,30 @@ class PP301(PyProject):
     def check(pyproject: dict[str, Any]) -> bool:
         """
         Must have a pytest configuration section in pyproject.toml. If you must
-        have it somewhere else (such as to support `pytest<6`), ignore this
+        have it somewhere else (such as to support `pytest<9`), ignore this
         check.
         """
 
         match pyproject:
-            case {"tool": {"pytest": {"ini_options": {}}}}:
+            case {"tool": {"pytest": {}}}:
                 return True
             case _:
                 return False
 
 
 class PP302(PyProject):
-    "Sets a minimum pytest to at least 6"
+    "Sets a minimum pytest to at least 9"
 
     requires = frozenset(("PP301",))
 
     @staticmethod
     def check(pyproject: dict[str, Any]) -> bool:
         """
-        Must have a `minversion=`, and must be at least 6 (first version to
-        support `pyproject.toml` configuration).
+        Must have a `minversion=`, and must be at least 9 (first version to
+        support native `pyproject.toml` configuration).
         """
-        options = pyproject["tool"]["pytest"]["ini_options"]
-        return "minversion" in options and float(options["minversion"]) >= 6
+        options = pyproject["tool"]["pytest"]
+        return "minversion" in options and float(options["minversion"]) >= 9
 
 
 class PP999(PyProject):


### PR DESCRIPTION
We require 3.10+, so can use pytest 9+.
