### PR TITLE
chore: faster & remove rich tracebacks

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -217,6 +217,7 @@ flake8-builtins.ignorelist = ["copyright", "print"]
 "typing.assert_never".msg = "Use repo_review._compat.typing.assert_never instead."
 "importlib.abc".msg = "Use repo_review._compat.importlib.resources.abc instead."
 "importlib.resources.abc".msg = "Use repo_review._compat.importlib.resources.abc instead."
+"typing.TYPE_CHECKING".msg = "Use TYPE_CHECKING=False instead"
 
 [tool.ruff.lint.per-file-ignores]
 "src/repo_review/_compat/**.py" = ["TID251"]

--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -15,6 +15,7 @@ __lazy_modules__ = [
     "repo_review.ghpath",
     "repo_review.html",
     "repo_review.processor",
+    "rich",
     "rich.console",
     "rich.markdown",
     "rich.syntax",
@@ -33,15 +34,9 @@ import itertools
 import json
 import os
 import sys
-import typing
 import urllib.error
 from pathlib import Path
 from typing import Any, Literal
-
-if typing.TYPE_CHECKING:
-    from collections.abc import Mapping
-
-    from ._compat.importlib.resources.abc import Traversable
 
 import rich
 import rich.console
@@ -49,7 +44,6 @@ import rich.markdown
 import rich.syntax
 import rich.terminal_theme
 import rich.text
-import rich.traceback
 import rich.tree
 
 from repo_review import __version__
@@ -60,6 +54,12 @@ from repo_review.ghpath import GHPath
 from repo_review.html import to_html
 from repo_review.processor import Result, as_simple_dict, collect_all, process
 
+TYPE_CHECKING = False
+if TYPE_CHECKING:
+    from collections.abc import Mapping
+
+    from ._compat.importlib.resources.abc import Traversable
+
 __all__ = ["Formats", "Show", "Status", "main"]
 
 CODE_THEME = "ansi_light"
@@ -68,8 +68,6 @@ CODE_THEME = "ansi_light"
 def __dir__() -> list[str]:
     return __all__
 
-
-rich.traceback.install(suppress=[rich], show_locals=False, width=None)
 
 Status = Literal["empty", "passed", "skips", "errors"]
 Formats = Literal["rich", "json", "html", "svg"]

--- a/src/repo_review/checks.py
+++ b/src/repo_review/checks.py
@@ -3,10 +3,11 @@ from __future__ import annotations
 __lazy_modules__ = [f"{__spec__.parent}.fixtures", "importlib", "importlib.metadata"]
 
 import importlib.metadata
-from typing import TYPE_CHECKING, Any, Protocol
+from typing import Any, Protocol
 
 from .fixtures import apply_fixtures
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from collections.abc import Mapping
     from collections.abc import Set as AbstractSet

--- a/src/repo_review/families.py
+++ b/src/repo_review/families.py
@@ -8,7 +8,8 @@ from typing import Any
 
 from .fixtures import apply_fixtures
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from collections.abc import Mapping
 
 __all__ = ["Family", "collect_families", "get_family_name"]

--- a/src/repo_review/fixtures.py
+++ b/src/repo_review/fixtures.py
@@ -18,7 +18,8 @@ from typing import Any
 from ._compat import tomllib
 from .ghpath import EmptyTraversable
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from collections.abc import Callable, Mapping
     from collections.abc import Set as AbstractSet
 

--- a/src/repo_review/ghpath.py
+++ b/src/repo_review/ghpath.py
@@ -4,7 +4,7 @@
 
 from __future__ import annotations
 
-__lazy_modules__ = ["io", "json", "sys"]
+__lazy_modules__ = ["io", "json", "sys", "typing"]
 
 import dataclasses
 import io
@@ -15,7 +15,8 @@ from typing import Literal
 
 from ._compat.importlib.resources.abc import Traversable
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from collections.abc import Iterator
 
 __all__ = ["EmptyTraversable", "GHPath"]

--- a/src/repo_review/html.py
+++ b/src/repo_review/html.py
@@ -11,12 +11,12 @@ __lazy_modules__ = [
 import builtins
 import functools
 import io
-import typing
 
 from .families import Family, get_family_description, get_family_name
 from .processor import Result, md_as_html
 
-if typing.TYPE_CHECKING:
+TYPE_CHECKING = False
+if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
 
     from .__main__ import Status

--- a/src/repo_review/processor.py
+++ b/src/repo_review/processor.py
@@ -20,7 +20,7 @@ import typing
 import warnings
 from collections.abc import Mapping
 from collections.abc import Set as AbstractSet
-from typing import TYPE_CHECKING, Any, TypeVar
+from typing import Any, TypeVar
 
 import markdown_it
 
@@ -36,6 +36,7 @@ from .families import Family, collect_families
 from .fixtures import apply_fixtures, collect_fixtures, compute_fixtures, pyproject
 from .ghpath import EmptyTraversable
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     import sys
 

--- a/tests/test_utilities/pyproject.py
+++ b/tests/test_utilities/pyproject.py
@@ -1,7 +1,8 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
+TYPE_CHECKING = False
 if TYPE_CHECKING:
     from repo_review._compat.importlib.resources.abc import Traversable
 


### PR DESCRIPTION
This further cuts down the imports and removes the custom traceback handler for the CLI. Goes from about 65 ms on Python 3.15 to 35 ms.
