### PR TITLE
ci: fix archive checksum changing after release

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,4 +1,3 @@
 node: $Format:%H$
 node-date: $Format:%cI$
 describe-name: $Format:%(describe:tags=true,match=*[0-9]*)$
-ref-names: $Format:%D$


### PR DESCRIPTION
This could sometimes change shortly after release. See https://github.com/conda-forge/repo-review-feedstock/pull/16.
