### PR TITLE
ci: split deploy-pages workflow into build and deploy jobs

### DIFF
--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -46,8 +46,8 @@ jobs:
     if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
-      pages: write
-      id-token: write
+      pages: write # needed for pages
+      id-token: write # needed for pages
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -3,6 +3,7 @@ name: Deploy Webapp to GitHub Pages
 on:
   push:
     branches: [main]
+  pull_request:
   workflow_dispatch:
 
 permissions: {}
@@ -42,6 +43,7 @@ jobs:
   deploy:
     name: Deploy
     needs: build
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     permissions:
       pages: write

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -12,12 +12,10 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  build-and-deploy:
-    name: Build and Deploy
+  build:
+    name: Build
     runs-on: ubuntu-latest
     permissions:
-      pages: write # needed for pages
-      id-token: write # needed for pages
       contents: read
     steps:
       - name: Checkout
@@ -36,13 +34,25 @@ jobs:
       - name: Build webapp
         run: bun run build-html
 
-      - name: Configure Pages
-        uses: actions/configure-pages@v6
-
       - name: Upload artifact for Pages
         uses: actions/upload-pages-artifact@v5
         with:
           path: out
 
+  deploy:
+    name: Deploy
+    needs: build
+    runs-on: ubuntu-latest
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Configure Pages
+        uses: actions/configure-pages@v6
+
       - name: Deploy to GitHub Pages
+        id: deployment
         uses: actions/deploy-pages@v5


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

Separate the monolithic `build-and-deploy` job into two jobs with an artifact between them:

- **Build job**: only needs `contents: read` permission — checks out code, installs deps, builds the webapp, and uploads the pages artifact
- **Deploy job**: has `pages: write` and `id-token: write` permissions, protected by a `github-pages` environment — configures pages and deploys

This follows the principle of least privilege by reducing the build environment's permissions and protects the deploy environment.

Assisted-by: OpenCode:glm-5