### PR TITLE
chore: bump version to 1.1.0

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -81,7 +81,7 @@ hatch run docs:serve
 You can rebuild the API docs with:
 
 ```bash
-$ hatch run api-docs:build
+hatch run api-docs:build
 ```
 
 ## Pre-commit
@@ -100,3 +100,13 @@ to check all files.
 
 You can use DevContainer, such as in GitHub Codespaces or locally. Hatch and a
 local install will be available.
+
+## Making a release
+
+Bump the version, for example to bump the patch:
+
+```bash
+hatch run version:bump bump patch
+```
+
+Push and make the release in GitHub, using the auto changelog.

--- a/docs/webapp.md
+++ b/docs/webapp.md
@@ -29,7 +29,7 @@ required:
 
   mountApp({
     header: false,
-    deps: ["repo-review~=1.0.0", "sp-repo-review==2026.04.04"],
+    deps: ["repo-review~=1.1.0", "sp-repo-review==2026.04.04"],
   });
 </script>
 ```
@@ -38,8 +38,8 @@ Pin to a specific version for stability:
 
 ```html
 <script type="module">
-  import { mountApp } from "https://cdn.jsdelivr.net/npm/repo-review-webapp@1.0.3/dist/repo-review-app.mjs";
-  mountApp({ header: false, deps: ["repo-review~=1.0.0"] });
+  import { mountApp } from "https://cdn.jsdelivr.net/npm/repo-review-webapp@1.1.0/dist/repo-review-app.mjs";
+  mountApp({ header: false, deps: ["repo-review~=1.1.0"] });
 </script>
 ```
 
@@ -76,7 +76,7 @@ And then after that, call the script with whatever dependencies you want:
 
   mountApp({
     header: false,
-    deps: ["repo-review~=1.0.0", "sp-repo-review==2026.04.04"],
+    deps: ["repo-review~=1.1.0", "sp-repo-review==2026.04.04"],
   });
 </script>
 ```

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "repo-review-webapp",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "type": "module",
   "exports": {
     ".": "./dist/repo-review-app.mjs"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "repo_review"
-version = "1.0.3"
+version = "1.1.0"
 authors = [
   { name = "Henry Schreiner", email = "henryfs@princeton.edu" },
 ]
@@ -267,3 +267,13 @@ filename = "package.json"
 
 [[tool.bumpversion.files]]
 filename = "src/repo_review/__init__.py"
+
+[[tool.bumpversion.files]]
+filename = "docs/webapp.md"
+search = "repo-review-webapp@{current_version}"
+replace = "repo-review-webapp@{new_version}"
+
+[[tool.bumpversion.files]]
+filename = "docs/webapp.md"
+search = "repo-review~={current_version}"
+replace = "repo-review~={new_version}"

--- a/src/repo_review/__init__.py
+++ b/src/repo_review/__init__.py
@@ -6,6 +6,6 @@ Review repos with a set of checks defined by plugins.
 
 from __future__ import annotations
 
-__version__ = "1.0.3"
+__version__ = "1.1.0"
 
 __all__ = ["__version__"]


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

## Summary

Bump version from 1.0.3 to 1.1.0.

### Changes
- Bump version in `pyproject.toml`, `__init__.py`, and `package.json`
- Add bumpversion config entries for `docs/webapp.md` (webapp CDN and dep version references) so future bumps update these too
- Add release instructions section to `CONTRIBUTING.md`
- Fix `$` prefix in CONTRIBUTING.md code block

Assisted-by: OpenCode:glm-5