### PR TITLE
ci: use npm trusted publishing for npm publish job

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -123,6 +123,9 @@ jobs:
     needs: [webapp-npm-make]
     if: github.event_name == 'release' && github.event.action == 'published'
     environment: npm
+    permissions:
+      contents: read # needed for checkout
+      id-token: write # needed for npm trusted publishing
 
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -134,16 +137,8 @@ jobs:
           name: repo-review-npm
           path: dist/
 
-      - name: Setup bun
-        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2.2.0
-        with:
-          bun-version: latest
-          no-cache: true
-
       - name: Publish to npm
-        run: bun publish --access public
-        env:
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish --provenance --access public
 
   publish:
     name: Publish

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -5,6 +5,3 @@ rules:
   artipacked:
     ignore:
       - cd.yml:72
-  use-trusted-publishing:
-    ignore:
-      - cd.yml:144


### PR DESCRIPTION
:robot: *Human guided, AI assisted PR ([using this skill](https://github.com/henryiii/skills/blob/main/branch-and-pr/SKILL.md)). AI text below.* :robot:

Switch from `bun publish` with `NPM_TOKEN` secret to `npm publish --provenance` for OIDC-based trusted publishing. This is more secure as it eliminates the need for a long-lived npm token secret.

Changes:
- Add explicit `permissions` (`contents: read`, `id-token: write`) to the `npm-publish` job
- Remove `oven-sh/setup-bun` step (no longer needed for publishing)
- Replace `bun publish --access public` with `npm publish --provenance --access public`
- Drop the zizmor `use-trusted-publishing` ignore rule for `cd.yml:144`

Assisted-by: OpenCode:glm-5