### PR TITLE
fix: GHPath iterdir/glob/is_dir traversal semantics

### DIFF
--- a/src/repo_review/ghpath.py
+++ b/src/repo_review/ghpath.py
@@ -4,15 +4,22 @@
 
 from __future__ import annotations
 
-__lazy_modules__ = [f"{__spec__.parent}._timer", "io", "json", "sys", "typing"]
+__lazy_modules__ = [
+    f"{__spec__.parent}._timer",
+    "fnmatch",
+    "io",
+    "json",
+    "sys",
+    "typing",
+]
 
 import dataclasses
+import fnmatch
 import io
 import json
 import logging
 import sys
 import typing
-from pathlib import PurePosixPath
 from typing import Literal
 
 from ._compat.importlib.resources.abc import Traversable
@@ -34,13 +41,33 @@ def __dir__() -> list[str]:
 logger = logging.getLogger(__name__)
 
 
+def _glob_match(pattern_parts: list[str], path_parts: list[str]) -> bool:
+    """
+    Match path components against glob pattern components, like
+    ``pathlib.Path.glob``. A ``**`` component matches zero or more path
+    components; other components are matched with ``fnmatch.fnmatchcase``.
+    """
+    if not pattern_parts:
+        return not path_parts
+    head, *rest = pattern_parts
+    if head == "**":
+        return any(
+            _glob_match(rest, path_parts[i:]) for i in range(len(path_parts) + 1)
+        )
+    return bool(
+        path_parts
+        and fnmatch.fnmatchcase(path_parts[0], head)
+        and _glob_match(rest, path_parts[1:])
+    )
+
+
 @dataclasses.dataclass(frozen=True, kw_only=True)
 class GHPath(Traversable):
     """
     This is a Traversable that can be used to navigate a GitHub repo without
     downloading it.
 
-    Will throw an KeyError if the response is not valid.
+    Will throw a KeyError if the response is not valid.
 
     :param repo: The repo name, in "org/repo" style.
     :param branch: The branch name. "HEAD" works too.
@@ -191,10 +218,11 @@ class GHPath(Traversable):
 
     def iterdir(self) -> Iterator[GHPath]:
         if self.path:
+            prefix = f"{self.path}/"
             yield from (
                 self._with_path(d["path"])
                 for d in self._info
-                if d["path"].startswith(self.path)
+                if d["path"].startswith(prefix) and "/" not in d["path"][len(prefix) :]
             )
         else:
             yield from (
@@ -203,8 +231,13 @@ class GHPath(Traversable):
 
     def glob(self, pattern: str) -> Iterator[GHPath]:
         """
-        Yield paths matching the given glob-style `pattern` relative to this
-        `GHPath`. Patterns support `**` recursion via PurePosixPath.match.
+        Yield paths matching the given glob-style ``pattern``, anchored at
+        this `GHPath` and matched against the full relative path, like
+        :meth:`pathlib.Path.glob`. Each ``/``-separated pattern component is
+        matched with :func:`fnmatch.fnmatchcase`, and a ``**`` component
+        matches zero or more path components. So ``"**/*.py"`` includes
+        top-level ``.py`` files, and ``"pyproject.toml"`` only matches the
+        direct child, not files nested in subdirectories.
 
         :param pattern: A glob pattern (e.g. ``"**/*.py"`` or ``"subdir/*.md"``).
 
@@ -212,24 +245,20 @@ class GHPath(Traversable):
         """
 
         base = self.path.rstrip("/")
-        base_path = PurePosixPath(base) if base else None
+        prefix = f"{base}/" if base else ""
+        pattern_parts = pattern.split("/")
 
         for entry in self._info:
-            entry_path = entry.get("path", "")
-            entry_pure_path = PurePosixPath(entry_path)
-
-            if base_path is not None:
-                try:
-                    relative_path = entry_pure_path.relative_to(base_path)
-                except ValueError:
-                    continue
-            else:
-                relative_path = entry_pure_path
-
-            if relative_path.match(pattern):
+            entry_path = entry["path"]
+            if prefix and not entry_path.startswith(prefix):
+                continue
+            relative_path = entry_path[len(prefix) :]
+            if _glob_match(pattern_parts, relative_path.split("/")):
                 yield self._with_path(entry_path)
 
     def is_dir(self) -> bool:
+        if not self.path:
+            return True
         return self.path in {d["path"] for d in self._info if d["type"] == "tree"}
 
     def is_file(self) -> bool:

--- a/tests/test_ghpath.py
+++ b/tests/test_ghpath.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import pytest
+
+from repo_review.ghpath import GHPath
+
+INFO = [
+    {"path": "pyproject.toml", "type": "blob"},
+    {"path": "README.md", "type": "blob"},
+    {"path": "docs", "type": "tree"},
+    {"path": "docs/pyproject.toml", "type": "blob"},
+    {"path": "docs/conf.py", "type": "blob"},
+    {"path": "src", "type": "tree"},
+    {"path": "src/a.py", "type": "blob"},
+    {"path": "src/sub", "type": "tree"},
+    {"path": "src/sub/b.py", "type": "blob"},
+    {"path": "src2", "type": "tree"},
+    {"path": "src2/c.py", "type": "blob"},
+]
+
+
+@pytest.fixture
+def root() -> GHPath:
+    return GHPath(repo="org/repo", branch="main", _info=INFO)
+
+
+def test_iterdir_root(root: GHPath) -> None:
+    assert {p.path for p in root.iterdir()} == {
+        "pyproject.toml",
+        "README.md",
+        "docs",
+        "src",
+        "src2",
+    }
+
+
+def test_iterdir_subdir_with_prefix_sibling(root: GHPath) -> None:
+    src = root / "src"
+    assert {p.path for p in src.iterdir()} == {"src/a.py", "src/sub"}
+
+
+def test_iterdir_nested_subdir(root: GHPath) -> None:
+    sub = root / "src" / "sub"
+    assert {p.path for p in sub.iterdir()} == {"src/sub/b.py"}
+
+
+def test_glob_is_anchored(root: GHPath) -> None:
+    assert {p.path for p in root.glob("pyproject.toml")} == {"pyproject.toml"}
+
+
+def test_glob_recursive(root: GHPath) -> None:
+    assert {p.path for p in root.glob("**/*.py")} == {
+        "docs/conf.py",
+        "src/a.py",
+        "src/sub/b.py",
+        "src2/c.py",
+    }
+
+
+def test_glob_single_star(root: GHPath) -> None:
+    assert {p.path for p in root.glob("*.py")} == set()
+    assert {p.path for p in root.glob("*/*.py")} == {
+        "docs/conf.py",
+        "src/a.py",
+        "src2/c.py",
+    }
+
+
+def test_glob_from_subdir(root: GHPath) -> None:
+    src = root / "src"
+    assert {p.path for p in src.glob("*.py")} == {"src/a.py"}
+    assert {p.path for p in src.glob("**/*.py")} == {"src/a.py", "src/sub/b.py"}
+    assert {p.path for p in src.glob("pyproject.toml")} == set()
+
+
+def test_joinpath_and_truediv(root: GHPath) -> None:
+    joined = root.joinpath("src")
+    divided = root / "src"
+    assert joined.path == "src"
+    assert divided.path == "src"
+    assert (divided / "sub").path == "src/sub"
+    assert joined.name == "src"
+
+
+def test_is_dir(root: GHPath) -> None:
+    assert root.is_dir()
+    assert (root / "src").is_dir()
+    assert (root / "src/sub").is_dir()
+    assert not (root / "src/a.py").is_dir()
+    assert not (root / "missing").is_dir()
+
+
+def test_is_file(root: GHPath) -> None:
+    assert not root.is_file()
+    assert (root / "pyproject.toml").is_file()
+    assert (root / "src/a.py").is_file()
+    assert not (root / "src").is_file()
+    assert not (root / "missing").is_file()


### PR DESCRIPTION
:robot: _AI text below_ :robot:

This fixes three traversal bugs in `GHPath` and adds the first tests for synchronous `GHPath` traversal (only async fetching was tested before).

### 1. `iterdir()` returned far more than direct children

The non-root branch filtered with `d["path"].startswith(self.path)`, which matched the directory itself, every recursive descendant, and prefix-siblings.

Before (listing `src` with `src2` present):

```python
{p.path for p in (root / "src").iterdir()}
# {'src', 'src/a.py', 'src/sub', 'src/sub/b.py', 'src2', 'src2/c.py'}
```

After:

```python
# {'src/a.py', 'src/sub'}
```

### 2. `glob()` didn't match its docstring or pathlib semantics

It used `PurePath.match()`, which is right-anchored suffix matching and treats `**` as a non-recursive `*`:

- `glob("pyproject.toml")` from the root also matched `docs/pyproject.toml` (at any depth). `process_prefetch_files` relies on this glob, so it could prefetch the wrong files.
- `glob("**/*.py")` missed top-level `.py` files.

Now `glob()` does anchored, pathlib-style matching: per-component `fnmatch`, with `**` matching zero or more path components.

```python
{p.path for p in root.glob("pyproject.toml")}   # before: {'pyproject.toml', 'docs/pyproject.toml'}; after: {'pyproject.toml'}
{p.path for p in root.glob("**/*.py")}          # now includes top-level .py files too
```

### 3. `is_dir()` was `False` for the repo root

The GitHub tree listing has no entry for `""`, so a root `GHPath` reported `is_dir() == False`, violating the `Traversable` contract. The root now returns `True`.

Also fixes a docstring typo ("an KeyError" -> "a KeyError").

🤖 Generated with [Claude Code](https://claude.com/claude-code)
