### PR TITLE
fix: core correctness fixes and polish

### DIFF
--- a/src/repo_review/__main__.py
+++ b/src/repo_review/__main__.py
@@ -476,10 +476,10 @@ def on_each(
 ) -> int:
     base_package: Traversable
 
-    ignore_list = {x.strip() for x in ignore.split(",") if x}
-    select_list = {x.strip() for x in select.split(",") if x}
-    extend_ignore_list = {x.strip() for x in extend_ignore.split(",") if x}
-    extend_select_list = {x.strip() for x in extend_select.split(",") if x}
+    ignore_list = {x.strip() for x in ignore.split(",") if x.strip()}
+    select_list = {x.strip() for x in select.split(",") if x.strip()}
+    extend_ignore_list = {x.strip() for x in extend_ignore.split(",") if x.strip()}
+    extend_select_list = {x.strip() for x in extend_select.split(",") if x.strip()}
 
     # Local paths support pointing at pyproject.toml as a special case
     match package:

--- a/src/repo_review/checks.py
+++ b/src/repo_review/checks.py
@@ -78,12 +78,12 @@ def collect_checks(fixtures: Mapping[str, Any]) -> dict[str, Check]:
 
 def name_matches(name: str, selectors: AbstractSet[str]) -> str:
     """
-    Checks if the name is contained in the matchers. The selectors can be the
+    Checks if the name is contained in the selectors. The selectors can be the
     exact name or just the non-number prefix. Returns the selector that matched,
     or an empty string if no match.
 
     :param name: The name to check.
-    :param expr: The expression to check against.
+    :param selectors: The selectors to check against.
 
     :return: The matched selector if the name matches a selector, or an empty string if no match.
     """

--- a/src/repo_review/families.py
+++ b/src/repo_review/families.py
@@ -15,6 +15,7 @@ if TYPE_CHECKING:
 __all__ = [
     "Family",
     "collect_families",
+    "get_family_description",
     "get_family_name",
     "sort_family_keys",
 ]
@@ -82,7 +83,7 @@ def get_family_description(families: Mapping[str, Family], family: str) -> str:
 
     :param families: A dict of family short names to :class:`.Family`'s.
     :param family: The short name of a family.
-    :return: The de-intended description if there is one, otherwise an empty string.
+    :return: The description if there is one, otherwise an empty string.
 
     .. versionadded:: 0.9
     """

--- a/src/repo_review/fixtures.py
+++ b/src/repo_review/fixtures.py
@@ -40,8 +40,8 @@ def __dir__() -> list[str]:
 
 def pyproject(package: Traversable) -> dict[str, Any]:
     """
-    Fixture: The ``pyproject.toml`` structure from the package. Returned an
-    empty dict if no pyproject.toml found.
+    Fixture: The ``pyproject.toml`` structure from the package. Returns an
+    empty dict if no pyproject.toml is found.
 
     :param package: The package fixture.
 
@@ -84,19 +84,25 @@ def compute_fixtures(
     :return: The fully evaluated dict of fixtures.
     """
     fixtures: dict[str, Any] = {"root": root, "package": package}
+    signatures = {
+        name: inspect.signature(fix) for name, fix in unevaluated_fixtures.items()
+    }
     graph: dict[str, AbstractSet[str]] = {"root": set(), "package": set()}
     graph |= {
-        name: inspect.signature(fix).parameters.keys()
-        for name, fix in unevaluated_fixtures.items()
+        name: signature.parameters.keys() for name, signature in signatures.items()
     }
+    for fixture_name, signature in signatures.items():
+        for name in signature.parameters:
+            if name not in graph:
+                msg = f"unknown fixture {name!r} requested by fixture {fixture_name!r}"
+                raise KeyError(msg)
     ts = graphlib.TopologicalSorter(graph)
     for fixture_name in ts.static_order():
         if fixture_name in {"package", "root"}:
             continue
         func = unevaluated_fixtures[fixture_name]
-        signature = inspect.signature(func)
-        kwargs = {name: fixtures[name] for name in signature.parameters}
-        fixtures[fixture_name] = unevaluated_fixtures[fixture_name](**kwargs)
+        kwargs = {name: fixtures[name] for name in signatures[fixture_name].parameters}
+        fixtures[fixture_name] = func(**kwargs)
     return fixtures
 
 

--- a/src/repo_review/html.py
+++ b/src/repo_review/html.py
@@ -109,10 +109,10 @@ def to_html(
         if status == "empty":
             print('<span style="color: red;">No checks ran.</span>')
         elif status == "passed":
-            print('<span style="color: red;">All checks passed.</span>')
+            print('<span style="color: green;">All checks passed.</span>')
         elif status == "skips":
             print(
-                '<span style="color: red;">All checks passed.</span> <span style="color: yellow;">(some checks skipped)</span>'
+                '<span style="color: green;">All checks passed.</span> <span style="color: yellow;">(some checks skipped)</span>'
             )
 
     return out.getvalue()

--- a/src/repo_review/processor.py
+++ b/src/repo_review/processor.py
@@ -72,7 +72,7 @@ md = markdown_it.MarkdownIt()
 
 def md_as_html(md_text: str) -> str:
     """
-    Heler function that converts markdown text to HTML. Strips paragraph tags from the result.
+    Helper function that converts markdown text to HTML. Strips paragraph tags from the result.
 
     :param md_text: The markdown text to convert.
     """
@@ -274,6 +274,12 @@ def process(
     # Run all the checks in topological order based on their dependencies
     ts = graphlib.TopologicalSorter(graph)
     for name in ts.static_order():
+        if name not in tasks:
+            # A check listed a dependency in `requires` that was not
+            # collected; it shows up in the topological order but has no
+            # task to run. Treat it as passed (matching `completed.get`
+            # below).
+            continue
         if all(completed.get(n, "") == "" for n in graph[name]):
             result = apply_fixtures({"name": name, **fixtures_copy}, tasks[name].check)
             completed[name] = process_result_bool(result, tasks[name], name)

--- a/src/repo_review/schema.py
+++ b/src/repo_review/schema.py
@@ -20,7 +20,9 @@ def __dir__() -> list[str]:
 
 def get_schema(tool_name: str = "repo-review") -> dict[str, Any]:
     """Get the stored complete schema for repo-review settings."""
-    assert tool_name == "repo-review", "Only repo-review is supported."
+    if tool_name != "repo-review":
+        msg = f"Only 'repo-review' is supported, got {tool_name!r}"
+        raise ValueError(msg)
 
     with resources.joinpath("repo-review.schema.json").open(encoding="utf-8") as f:
         return json.load(f)  # type: ignore[no-any-return]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,7 +5,7 @@ import pytest
 
 @pytest.fixture(autouse=True)
 def nocolor(monkeypatch: pytest.MonkeyPatch) -> None:
-    monkeypatch.delenv("NOCOLOR", raising=False)
+    monkeypatch.delenv("NO_COLOR", raising=False)
     monkeypatch.delenv("FORCE_COLOR", raising=False)
 
 

--- a/tests/test_depends.py
+++ b/tests/test_depends.py
@@ -35,6 +35,21 @@ class E200:
         return True
 
 
+class E300:
+    "Depends on a check that doesn't exist"
+
+    family = "example"
+    requires = frozenset(["E999"])
+
+    @staticmethod
+    def check() -> bool:
+        """
+        Can't be false.
+        """
+
+        return True
+
+
 def test_ignore_filter_single(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(
         repo_review.processor,
@@ -59,3 +74,19 @@ def test_select_filter_single(monkeypatch: pytest.MonkeyPatch) -> None:
     assert len(results) == 1
     assert results[0].name == "E200"
     assert results[0].result
+
+
+def test_requires_missing_check(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        repo_review.processor,
+        "collect_checks",
+        lambda _: {"E100": E100, "E300": E300},
+    )
+    _, results = repo_review.processor.process(Path())
+
+    assert len(results) == 2
+    assert results[0].name == "E100"
+    assert results[0].result
+    # The missing dependency is treated as passed, so the check still runs.
+    assert results[1].name == "E300"
+    assert results[1].result

--- a/tests/test_fixtures.py
+++ b/tests/test_fixtures.py
@@ -83,6 +83,14 @@ def test_process_fixtures_with_package() -> None:
     assert apply_fixtures(fixtures, not_simple) == ". ."
 
 
+def test_unknown_fixture_error() -> None:
+    def bad_fixture(does_not_exist: str) -> str:
+        return does_not_exist
+
+    with pytest.raises(KeyError, match="unknown fixture 'does_not_exist'"):
+        compute_fixtures(Path(), Path(), {"bad_fixture": bad_fixture})
+
+
 @pytest.mark.parametrize("some_bool", [True, False])
 def test_process_checks(monkeypatch: pytest.MonkeyPatch, some_bool: bool) -> None:
     ep = importlib.metadata.EntryPoint(name="x", group="y", value="test_module:f")


### PR DESCRIPTION
:robot: _AI text below_ :robot:

A batch of verified core-Python fixes and polish. Intentionally does not touch `ghpath.py` or `pyproject.toml` (covered by other PRs in flight).

## Bugs

- **`processor.process()` raised a raw `KeyError`** when a check's `requires` named a check that wasn't collected: `ts.static_order()` yields predecessor-only nodes, but the graph only has collected keys. Now skips uncollected names; a missing dependency is still treated as passed (matching the existing `completed.get(n, "")` default). Added a test in `tests/test_depends.py`.
- **`html.to_html()` rendered "All checks passed." in red** in both the `passed` and `skips` branches (copy-paste from the `empty` branch). Now green, matching the rich CLI output; the skip note stays yellow.
- **`tests/conftest.py` deleted the env var `NOCOLOR`**, but rich's standard variable is `NO_COLOR`. Fixed the name.

## Polish

- **`families`**: `get_family_description` is public documented API but was missing from `__all__` (and thus `__dir__()`). Added.
- **`schema.get_schema()`**: validated `tool_name` with `assert`, which disappears under `python -O`; it's an external entry point called by validate-pyproject. Now raises an explicit `ValueError` with a clear message.
- **`fixtures.compute_fixtures()`**: computed `inspect.signature` twice per fixture and re-looked-up `unevaluated_fixtures[fixture_name]` despite already holding `func`. Signatures are now computed once and `func` is used directly. Also, a fixture parameter that isn't a known fixture now raises a clear `KeyError` naming the offending fixture and parameter instead of crashing with a bare `KeyError` on the unknown name. Added a test.
- **`__main__`**: comma-list parsing filtered before stripping, so a whitespace-only segment produced `""` in the select/ignore sets. Now filters on the stripped value (all four of select/ignore/extend-select/extend-ignore).
- **Docstring fixes**: "Heler function" typo in `processor.md_as_html`; `checks.name_matches` documented a nonexistent `expr` parameter and called the selectors "matchers"; `families.get_family_description` claimed a "de-intended" description (it does not dedent); `fixtures.pyproject` grammar.

🤖 Generated with [Claude Code](https://claude.com/claude-code)