### PR TITLE
fix: webapp security, races, and lint enforcement

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -17,12 +17,11 @@
         "@types/bun": "^1.3.11",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
-        "@typescript-eslint/eslint-plugin": "^8.58.0",
-        "@typescript-eslint/parser": "^8.58.0",
         "esbuild": "^0.27.4",
         "eslint": "^10.1.0",
         "eslint-config-prettier": "^10.1.8",
         "eslint-plugin-react": "^7.37.5",
+        "eslint-plugin-react-hooks": "^7.1.1",
         "prettier": "^3.8.3",
         "typescript": "^6.0.2",
         "typescript-eslint": "^8.58.0",
@@ -30,27 +29,39 @@
     },
   },
   "packages": {
-    "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+    "@babel/code-frame": ["@babel/code-frame@7.29.7", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.29.7", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw=="],
 
-    "@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+    "@babel/compat-data": ["@babel/compat-data@7.29.7", "", {}, "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg=="],
 
-    "@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+    "@babel/core": ["@babel/core@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-compilation-targets": "^7.29.7", "@babel/helper-module-transforms": "^7.29.7", "@babel/helpers": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/remapping": "^2.3.5", "convert-source-map": "^2.0.0", "debug": "^4.1.0", "gensync": "^1.0.0-beta.2", "json5": "^2.2.3", "semver": "^6.3.1" } }, "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA=="],
+
+    "@babel/generator": ["@babel/generator@7.29.7", "", { "dependencies": { "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ=="],
+
+    "@babel/helper-compilation-targets": ["@babel/helper-compilation-targets@7.29.7", "", { "dependencies": { "@babel/compat-data": "^7.29.7", "@babel/helper-validator-option": "^7.29.7", "browserslist": "^4.24.0", "lru-cache": "^5.1.1", "semver": "^6.3.1" } }, "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g=="],
+
+    "@babel/helper-globals": ["@babel/helper-globals@7.29.7", "", {}, "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA=="],
 
     "@babel/helper-module-imports": ["@babel/helper-module-imports@7.28.6", "", { "dependencies": { "@babel/traverse": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw=="],
 
-    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+    "@babel/helper-module-transforms": ["@babel/helper-module-transforms@7.29.7", "", { "dependencies": { "@babel/helper-module-imports": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7", "@babel/traverse": "^7.29.7" }, "peerDependencies": { "@babel/core": "^7.0.0" } }, "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg=="],
 
-    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.29.7", "", {}, "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.29.7", "", {}, "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg=="],
+
+    "@babel/helper-validator-option": ["@babel/helper-validator-option@7.29.7", "", {}, "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw=="],
+
+    "@babel/helpers": ["@babel/helpers@7.29.7", "", { "dependencies": { "@babel/template": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg=="],
 
     "@babel/parser": ["@babel/parser@7.29.2", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": "./bin/babel-parser.js" }, "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA=="],
 
     "@babel/runtime": ["@babel/runtime@7.29.2", "", {}, "sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g=="],
 
-    "@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+    "@babel/template": ["@babel/template@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg=="],
 
-    "@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+    "@babel/traverse": ["@babel/traverse@7.29.7", "", { "dependencies": { "@babel/code-frame": "^7.29.7", "@babel/generator": "^7.29.7", "@babel/helper-globals": "^7.29.7", "@babel/parser": "^7.29.7", "@babel/template": "^7.29.7", "@babel/types": "^7.29.7", "debug": "^4.3.1" } }, "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw=="],
 
-    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+    "@babel/types": ["@babel/types@7.29.7", "", { "dependencies": { "@babel/helper-string-parser": "^7.29.7", "@babel/helper-validator-identifier": "^7.29.7" } }, "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA=="],
 
     "@emotion/babel-plugin": ["@emotion/babel-plugin@11.13.5", "", { "dependencies": { "@babel/helper-module-imports": "^7.16.7", "@babel/runtime": "^7.18.3", "@emotion/hash": "^0.9.2", "@emotion/memoize": "^0.9.0", "@emotion/serialize": "^1.3.3", "babel-plugin-macros": "^3.1.0", "convert-source-map": "^1.5.0", "escape-string-regexp": "^4.0.0", "find-root": "^1.1.0", "source-map": "^0.5.7", "stylis": "4.2.0" } }, "sha512-pxHCpT2ex+0q+HH91/zsdHkw/lXd468DIN2zvfvLtPKLLMo6gQj7oLObq8PhkrxOZb/gGCq03S3Z7PDhS8pduQ=="],
 
@@ -154,6 +165,8 @@
 
     "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
 
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
     "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
@@ -248,7 +261,11 @@
 
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
 
+    "baseline-browser-mapping": ["baseline-browser-mapping@2.10.35", "", { "bin": { "baseline-browser-mapping": "dist/cli.cjs" } }, "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg=="],
+
     "brace-expansion": ["brace-expansion@5.0.5", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ=="],
+
+    "browserslist": ["browserslist@4.28.2", "", { "dependencies": { "baseline-browser-mapping": "^2.10.12", "caniuse-lite": "^1.0.30001782", "electron-to-chromium": "^1.5.328", "node-releases": "^2.0.36", "update-browserslist-db": "^1.2.3" }, "bin": { "browserslist": "cli.js" } }, "sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg=="],
 
     "bun-types": ["bun-types@1.3.11", "", { "dependencies": { "@types/node": "*" } }, "sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg=="],
 
@@ -260,11 +277,13 @@
 
     "callsites": ["callsites@3.1.0", "", {}, "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="],
 
+    "caniuse-lite": ["caniuse-lite@1.0.30001797", "", {}, "sha512-l8xKG+gwAIExZGl9FrF7KUwuOmk6wbEPC9Xoy/RtnWv1XG0Q4LFlagaLpUv3Kiza3W/wm27zy0yWJEieYKAP6w=="],
+
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
     "concat-map": ["concat-map@0.0.1", "", {}, "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="],
 
-    "convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
+    "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "cosmiconfig": ["cosmiconfig@7.1.0", "", { "dependencies": { "@types/parse-json": "^4.0.0", "import-fresh": "^3.2.1", "parse-json": "^5.0.0", "path-type": "^4.0.0", "yaml": "^1.10.0" } }, "sha512-AdmX6xUzdNASswsFtmwSt7Vj8po9IuqXm0UXz7QKPuEUmPB4XyjGfaAr2PSuELMwkRMVH1EpIkX5bTZGRB3eCA=="],
 
@@ -292,6 +311,8 @@
 
     "dunder-proto": ["dunder-proto@1.0.1", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.1", "es-errors": "^1.3.0", "gopd": "^1.2.0" } }, "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A=="],
 
+    "electron-to-chromium": ["electron-to-chromium@1.5.371", "", {}, "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w=="],
+
     "error-ex": ["error-ex@1.3.4", "", { "dependencies": { "is-arrayish": "^0.2.1" } }, "sha512-sqQamAnR14VgCr1A618A3sGrygcpK+HEbenA/HiEAkkUwcZIIB/tgWqHFxWgOyDh4nB4JCRimh79dR5Ywc9MDQ=="],
 
     "es-abstract": ["es-abstract@1.24.1", "", { "dependencies": { "array-buffer-byte-length": "^1.0.2", "arraybuffer.prototype.slice": "^1.0.4", "available-typed-arrays": "^1.0.7", "call-bind": "^1.0.8", "call-bound": "^1.0.4", "data-view-buffer": "^1.0.2", "data-view-byte-length": "^1.0.2", "data-view-byte-offset": "^1.0.1", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "es-set-tostringtag": "^2.1.0", "es-to-primitive": "^1.3.0", "function.prototype.name": "^1.1.8", "get-intrinsic": "^1.3.0", "get-proto": "^1.0.1", "get-symbol-description": "^1.1.0", "globalthis": "^1.0.4", "gopd": "^1.2.0", "has-property-descriptors": "^1.0.2", "has-proto": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "internal-slot": "^1.1.0", "is-array-buffer": "^3.0.5", "is-callable": "^1.2.7", "is-data-view": "^1.0.2", "is-negative-zero": "^2.0.3", "is-regex": "^1.2.1", "is-set": "^2.0.3", "is-shared-array-buffer": "^1.0.4", "is-string": "^1.1.1", "is-typed-array": "^1.1.15", "is-weakref": "^1.1.1", "math-intrinsics": "^1.1.0", "object-inspect": "^1.13.4", "object-keys": "^1.1.1", "object.assign": "^4.1.7", "own-keys": "^1.0.1", "regexp.prototype.flags": "^1.5.4", "safe-array-concat": "^1.1.3", "safe-push-apply": "^1.0.0", "safe-regex-test": "^1.1.0", "set-proto": "^1.0.0", "stop-iteration-iterator": "^1.1.0", "string.prototype.trim": "^1.2.10", "string.prototype.trimend": "^1.0.9", "string.prototype.trimstart": "^1.0.8", "typed-array-buffer": "^1.0.3", "typed-array-byte-length": "^1.0.3", "typed-array-byte-offset": "^1.0.4", "typed-array-length": "^1.0.7", "unbox-primitive": "^1.1.0", "which-typed-array": "^1.1.19" } }, "sha512-zHXBLhP+QehSSbsS9Pt23Gg964240DPd6QCf8WpkqEXxQ7fhdZzYsocOr5u7apWonsS5EjZDmTF+/slGMyasvw=="],
@@ -312,6 +333,8 @@
 
     "esbuild": ["esbuild@0.27.4", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.4", "@esbuild/android-arm": "0.27.4", "@esbuild/android-arm64": "0.27.4", "@esbuild/android-x64": "0.27.4", "@esbuild/darwin-arm64": "0.27.4", "@esbuild/darwin-x64": "0.27.4", "@esbuild/freebsd-arm64": "0.27.4", "@esbuild/freebsd-x64": "0.27.4", "@esbuild/linux-arm": "0.27.4", "@esbuild/linux-arm64": "0.27.4", "@esbuild/linux-ia32": "0.27.4", "@esbuild/linux-loong64": "0.27.4", "@esbuild/linux-mips64el": "0.27.4", "@esbuild/linux-ppc64": "0.27.4", "@esbuild/linux-riscv64": "0.27.4", "@esbuild/linux-s390x": "0.27.4", "@esbuild/linux-x64": "0.27.4", "@esbuild/netbsd-arm64": "0.27.4", "@esbuild/netbsd-x64": "0.27.4", "@esbuild/openbsd-arm64": "0.27.4", "@esbuild/openbsd-x64": "0.27.4", "@esbuild/openharmony-arm64": "0.27.4", "@esbuild/sunos-x64": "0.27.4", "@esbuild/win32-arm64": "0.27.4", "@esbuild/win32-ia32": "0.27.4", "@esbuild/win32-x64": "0.27.4" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ=="],
 
+    "escalade": ["escalade@3.2.0", "", {}, "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA=="],
+
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "eslint": ["eslint@10.1.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.3", "@eslint/config-helpers": "^0.5.3", "@eslint/core": "^1.1.1", "@eslint/plugin-kit": "^0.6.1", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-S9jlY/ELKEUwwQnqWDO+f+m6sercqOPSqXM5Go94l7DOmxHVDgmSFGWEzeE/gwgTAr0W103BWt0QLe/7mabIvA=="],
@@ -319,6 +342,8 @@
     "eslint-config-prettier": ["eslint-config-prettier@10.1.8", "", { "peerDependencies": { "eslint": ">=7.0.0" }, "bin": { "eslint-config-prettier": "bin/cli.js" } }, "sha512-82GZUjRS0p/jganf6q1rEO25VSoHH0hKPCTrgillPjdI/3bgBhAE1QzHrHTizjpRvy6pGAvKjDJtk2pF9NDq8w=="],
 
     "eslint-plugin-react": ["eslint-plugin-react@7.37.5", "", { "dependencies": { "array-includes": "^3.1.8", "array.prototype.findlast": "^1.2.5", "array.prototype.flatmap": "^1.3.3", "array.prototype.tosorted": "^1.1.4", "doctrine": "^2.1.0", "es-iterator-helpers": "^1.2.1", "estraverse": "^5.3.0", "hasown": "^2.0.2", "jsx-ast-utils": "^2.4.1 || ^3.0.0", "minimatch": "^3.1.2", "object.entries": "^1.1.9", "object.fromentries": "^2.0.8", "object.values": "^1.2.1", "prop-types": "^15.8.1", "resolve": "^2.0.0-next.5", "semver": "^6.3.1", "string.prototype.matchall": "^4.0.12", "string.prototype.repeat": "^1.0.0" }, "peerDependencies": { "eslint": "^3 || ^4 || ^5 || ^6 || ^7 || ^8 || ^9.7" } }, "sha512-Qteup0SqU15kdocexFNAJMvCJEfa2xUKNV4CC1xsVMrIIqEy3SQ/rqyxCWNzfrd3/ldy6HMlD2e0JDVpDg2qIA=="],
+
+    "eslint-plugin-react-hooks": ["eslint-plugin-react-hooks@7.1.1", "", { "dependencies": { "@babel/core": "^7.24.4", "@babel/parser": "^7.24.4", "hermes-parser": "^0.25.1", "zod": "^3.25.0 || ^4.0.0", "zod-validation-error": "^3.5.0 || ^4.0.0" }, "peerDependencies": { "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0" } }, "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g=="],
 
     "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
 
@@ -362,6 +387,8 @@
 
     "generator-function": ["generator-function@2.0.1", "", {}, "sha512-SFdFmIJi+ybC0vjlHN0ZGVGHc3lgE0DxPAT0djjVg+kjOnSqclqmj0KQ7ykTOLP6YxoqOvuAODGdcHJn+43q3g=="],
 
+    "gensync": ["gensync@1.0.0-beta.2", "", {}, "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="],
+
     "get-intrinsic": ["get-intrinsic@1.3.0", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.2", "es-define-property": "^1.0.1", "es-errors": "^1.3.0", "es-object-atoms": "^1.1.1", "function-bind": "^1.1.2", "get-proto": "^1.0.1", "gopd": "^1.2.0", "has-symbols": "^1.1.0", "hasown": "^2.0.2", "math-intrinsics": "^1.1.0" } }, "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ=="],
 
     "get-proto": ["get-proto@1.0.1", "", { "dependencies": { "dunder-proto": "^1.0.1", "es-object-atoms": "^1.0.0" } }, "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g=="],
@@ -386,9 +413,13 @@
 
     "hasown": ["hasown@2.0.2", "", { "dependencies": { "function-bind": "^1.1.2" } }, "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ=="],
 
+    "hermes-estree": ["hermes-estree@0.25.1", "", {}, "sha512-0wUoCcLp+5Ev5pDW2OriHC2MJCbwLwuRx+gAqMTOkGKJJiBCLjtrvy4PWUGn6MIVefecRpzoOZ/UV6iGdOr+Cw=="],
+
+    "hermes-parser": ["hermes-parser@0.25.1", "", { "dependencies": { "hermes-estree": "0.25.1" } }, "sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA=="],
+
     "hoist-non-react-statics": ["hoist-non-react-statics@3.3.2", "", { "dependencies": { "react-is": "^16.7.0" } }, "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw=="],
 
-    "ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "import-fresh": ["import-fresh@3.3.1", "", { "dependencies": { "parent-module": "^1.0.0", "resolve-from": "^4.0.0" } }, "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ=="],
 
@@ -464,6 +495,8 @@
 
     "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
 
+    "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
     "jsx-ast-utils": ["jsx-ast-utils@3.3.5", "", { "dependencies": { "array-includes": "^3.1.6", "array.prototype.flat": "^1.3.1", "object.assign": "^4.1.4", "object.values": "^1.1.6" } }, "sha512-ZZow9HBI5O6EPgSJLUb8n2NKgmVWTwCvHGwFuJlMjvLFqlGG6pjirPhtdsseaLZjSibD8eegzmYpUZwoIlj2cQ=="],
 
     "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
@@ -476,6 +509,8 @@
 
     "loose-envify": ["loose-envify@1.4.0", "", { "dependencies": { "js-tokens": "^3.0.0 || ^4.0.0" }, "bin": { "loose-envify": "cli.js" } }, "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q=="],
 
+    "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
+
     "math-intrinsics": ["math-intrinsics@1.1.0", "", {}, "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g=="],
 
     "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
@@ -485,6 +520,8 @@
     "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "node-exports-info": ["node-exports-info@1.6.0", "", { "dependencies": { "array.prototype.flatmap": "^1.3.3", "es-errors": "^1.3.0", "object.entries": "^1.1.9", "semver": "^6.3.1" } }, "sha512-pyFS63ptit/P5WqUkt+UUfe+4oevH+bFeIiPPdfb0pFeYEu/1ELnJu5l+5EcTKYL5M7zaAa7S8ddywgXypqKCw=="],
+
+    "node-releases": ["node-releases@2.0.47", "", {}, "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og=="],
 
     "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
 
@@ -620,6 +657,8 @@
 
     "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
+    "update-browserslist-db": ["update-browserslist-db@1.2.3", "", { "dependencies": { "escalade": "^3.2.0", "picocolors": "^1.1.1" }, "peerDependencies": { "browserslist": ">= 4.21.0" }, "bin": { "update-browserslist-db": "cli.js" } }, "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w=="],
+
     "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
@@ -636,25 +675,71 @@
 
     "ws": ["ws@8.20.0", "", { "peerDependencies": { "bufferutil": "^4.0.1", "utf-8-validate": ">=5.0.2" }, "optionalPeers": ["bufferutil", "utf-8-validate"] }, "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA=="],
 
+    "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
+
     "yaml": ["yaml@1.10.3", "", {}, "sha512-vIYeF1u3CjlhAFekPPAk2h/Kv4T3mAkMox5OymRiJQB0spDP10LHvt+K7G9Ny6NuuMAb25/6n1qyUjAcGNf/AA=="],
 
     "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
 
+    "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
+
+    "zod-validation-error": ["zod-validation-error@4.0.2", "", { "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-Q6/nZLe6jxuU80qb/4uJ4t5v2VEZ44lzQjPDhYJNztRQ4wyWc6VF3D3Kb/fAuPetZQnhS3hnajCf9CsWesghLQ=="],
+
+    "@babel/core/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/generator/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/helper-module-imports/@babel/traverse": ["@babel/traverse@7.29.0", "", { "dependencies": { "@babel/code-frame": "^7.29.0", "@babel/generator": "^7.29.0", "@babel/helper-globals": "^7.28.0", "@babel/parser": "^7.29.0", "@babel/template": "^7.28.6", "@babel/types": "^7.29.0", "debug": "^4.3.1" } }, "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA=="],
+
+    "@babel/helper-module-imports/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@babel/helper-module-transforms/@babel/helper-module-imports": ["@babel/helper-module-imports@7.29.7", "", { "dependencies": { "@babel/traverse": "^7.29.7", "@babel/types": "^7.29.7" } }, "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g=="],
+
+    "@babel/parser/@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@babel/template/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@babel/traverse/@babel/parser": ["@babel/parser@7.29.7", "", { "dependencies": { "@babel/types": "^7.29.7" }, "bin": "./bin/babel-parser.js" }, "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg=="],
+
+    "@emotion/babel-plugin/convert-source-map": ["convert-source-map@1.9.0", "", {}, "sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A=="],
+
     "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.5", "", {}, "sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg=="],
 
     "@typescript-eslint/typescript-estree/semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "babel-plugin-macros/resolve": ["resolve@1.22.11", "", { "dependencies": { "is-core-module": "^2.16.1", "path-parse": "^1.0.7", "supports-preserve-symlinks-flag": "^1.0.0" }, "bin": { "resolve": "bin/resolve" } }, "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ=="],
 
-    "eslint/ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
-
     "eslint-plugin-react/minimatch": ["minimatch@3.1.5", "", { "dependencies": { "brace-expansion": "^1.1.7" } }, "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w=="],
 
     "hoist-non-react-statics/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "parse-json/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
     "prop-types/react-is": ["react-is@16.13.1", "", {}, "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="],
 
+    "@babel/helper-module-imports/@babel/traverse/@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
+
+    "@babel/helper-module-imports/@babel/traverse/@babel/generator": ["@babel/generator@7.29.1", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "@jridgewell/gen-mapping": "^0.3.12", "@jridgewell/trace-mapping": "^0.3.28", "jsesc": "^3.0.2" } }, "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw=="],
+
+    "@babel/helper-module-imports/@babel/traverse/@babel/helper-globals": ["@babel/helper-globals@7.28.0", "", {}, "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw=="],
+
+    "@babel/helper-module-imports/@babel/traverse/@babel/template": ["@babel/template@7.28.6", "", { "dependencies": { "@babel/code-frame": "^7.28.6", "@babel/parser": "^7.28.6", "@babel/types": "^7.28.6" } }, "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ=="],
+
+    "@babel/helper-module-imports/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-module-imports/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser/@babel/types/@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/parser/@babel/types/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
     "eslint-plugin-react/minimatch/brace-expansion": ["brace-expansion@1.1.13", "", { "dependencies": { "balanced-match": "^1.0.0", "concat-map": "0.0.1" } }, "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w=="],
+
+    "parse-json/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/helper-module-imports/@babel/traverse/@babel/code-frame/@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
 
     "eslint-plugin-react/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
   }

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,29 +1,35 @@
-import { createRequire } from "module";
-import { defineConfig } from "eslint/config";
+import { defineConfig, globalIgnores } from "eslint/config";
+import tseslint from "typescript-eslint";
+import react from "eslint-plugin-react";
+import reactHooks from "eslint-plugin-react-hooks";
+import prettier from "eslint-config-prettier";
 
-const require = createRequire(import.meta.url);
-
-const tsPlugin = require("@typescript-eslint/eslint-plugin");
-const reactPlugin = require("eslint-plugin-react");
-
-export default defineConfig({
-  ignores: ["docs/**", ".venv/**", "docs/_static/**", "docs/_build/**"],
-  languageOptions: {
-    parser: require("@typescript-eslint/parser"),
-    parserOptions: {
-      ecmaVersion: 2020,
-      sourceType: "module",
-      ecmaFeatures: { jsx: true },
+export default defineConfig(
+  globalIgnores([
+    "docs/**",
+    "dist/**",
+    "out/**",
+    ".venv/**",
+    "node_modules/**",
+  ]),
+  {
+    files: ["src/**/*.{ts,tsx}", "*.{js,mjs,cjs}"],
+    extends: [
+      tseslint.configs.recommended,
+      react.configs.flat.recommended,
+      react.configs.flat["jsx-runtime"],
+      reactHooks.configs.flat.recommended,
+      prettier,
+    ],
+    settings: {
+      // eslint-plugin-react's "detect" mode crashes under ESLint 10
+      // (it relies on the removed context.getFilename API), so pin it.
+      react: { version: "19" },
+    },
+    rules: {
+      "react/react-in-jsx-scope": "off",
+      // Props are typed with TypeScript interfaces instead of PropTypes
+      "react/prop-types": "off",
     },
   },
-  plugins: {
-    "@typescript-eslint": tsPlugin,
-    react: reactPlugin,
-  },
-  settings: {
-    react: { version: "detect" },
-  },
-  rules: {
-    "react/react-in-jsx-scope": "off",
-  },
-});
+);

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "build-anywidget": "bunx esbuild src/repo-review-app/anywidget.tsx --bundle --minify --sourcemap --outfile=dist/repo-review-anywidget.mjs --platform=browser --format=esm",
     "build-html": "bun build src/repo-review-app/index.html --outdir=out --minify",
     "format": "prettier --write .",
-    "lint": "eslint . --ext .ts,.tsx,.js,.jsx",
+    "lint": "eslint .",
     "serve": "bun src/repo-review-app/index.html",
     "test": "bun test",
     "type": "tsc --noEmit"
@@ -45,12 +45,11 @@
     "@types/bun": "^1.3.11",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
-    "@typescript-eslint/eslint-plugin": "^8.58.0",
-    "@typescript-eslint/parser": "^8.58.0",
     "esbuild": "^0.27.4",
     "eslint": "^10.1.0",
     "eslint-config-prettier": "^10.1.8",
     "eslint-plugin-react": "^7.37.5",
+    "eslint-plugin-react-hooks": "^7.1.1",
     "prettier": "^3.8.3",
     "typescript": "^6.0.2",
     "typescript-eslint": "^8.58.0"

--- a/src/repo-review-app/anywidget.tsx
+++ b/src/repo-review-app/anywidget.tsx
@@ -16,7 +16,6 @@
  *   - url_sync (boolean, optional): Enable URL syncing. Disabled by default
  *     when embedded as a widget.
  */
-import React from "react";
 import ReactDOM from "react-dom/client";
 import createCache from "@emotion/cache";
 import { CacheProvider } from "@emotion/react";

--- a/src/repo-review-app/components/Heading.tsx
+++ b/src/repo-review-app/components/Heading.tsx
@@ -1,7 +1,6 @@
-import React from "react";
 import { Box, AppBar, Toolbar, Typography, Button } from "@mui/material";
 
-export default function Heading(props: any) {
+export default function Heading() {
   return (
     <Box sx={{ flexGrow: 1, mb: 2 }}>
       <AppBar position="static">

--- a/src/repo-review-app/components/IfUrlLink.test.tsx
+++ b/src/repo-review-app/components/IfUrlLink.test.tsx
@@ -2,7 +2,6 @@
 // extra dependencies required. Assertions are over the rendered HTML string.
 import { describe, it, expect } from "bun:test";
 import { renderToStaticMarkup } from "react-dom/server";
-import React from "react";
 import IfUrlLink from "./IfUrlLink";
 
 describe("IfUrlLink", () => {

--- a/src/repo-review-app/components/IfUrlLink.tsx
+++ b/src/repo-review-app/components/IfUrlLink.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import { Typography } from "@mui/material";
 
 export default function IfUrlLink({

--- a/src/repo-review-app/components/MyThemeProvider.tsx
+++ b/src/repo-review-app/components/MyThemeProvider.tsx
@@ -42,7 +42,7 @@ function usePageTheme(): PageTheme {
   return { darkMode: pageClass ?? false, hostControlled: pageClass !== null };
 }
 
-export default function MyThemeProvider(props: any) {
+export default function MyThemeProvider(props: { children: React.ReactNode }) {
   const { darkMode: pageDark, hostControlled } = usePageTheme();
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
 

--- a/src/repo-review-app/components/Results.tsx
+++ b/src/repo-review-app/components/Results.tsx
@@ -1,4 +1,3 @@
-import React from "react";
 import {
   List,
   ListItem,
@@ -12,12 +11,19 @@ import ReportIcon from "@mui/icons-material/Report";
 import CheckBoxIcon from "@mui/icons-material/CheckBox";
 import InfoIcon from "@mui/icons-material/Info";
 import IfUrlLink from "./IfUrlLink";
+import type { ReactNode } from "react";
+import type { CheckItem } from "../repo-review-app";
 
-export default function Results(props: any) {
-  const output: any[] = [];
+interface ResultsProps {
+  results: Record<string, CheckItem[]>;
+  families: Record<string, { name: string; description?: string }>;
+}
+
+export default function Results(props: ResultsProps) {
+  const output: ReactNode[] = [];
   for (const key in props.results) {
     const inner_results = props.results[key];
-    const results_components = inner_results.map((result: any) => {
+    const results_components = inner_results.map((result: CheckItem) => {
       const text_color =
         result.state === false
           ? "error.main"
@@ -26,7 +32,7 @@ export default function Results(props: any) {
             : "info.main";
       const details =
         result.state === false ? (
-          <span dangerouslySetInnerHTML={{ __html: result.err_msg }} />
+          <span dangerouslySetInnerHTML={{ __html: result.err_msg ?? "" }} />
         ) : null;
       const icon =
         result.state === false ? (
@@ -50,16 +56,14 @@ export default function Results(props: any) {
       const msg = (
         <>
           <IfUrlLink name={result.name} url={result.url} color={text_color} />
-          <IfUrlLink name={": "} url={""} color={text_color} />
-          <>
-            <Typography
-              sx={{ display: "inline" }}
-              component="span"
-              color={text_color}
-            >
-              {result.description}
-            </Typography>
-          </>
+          <Typography
+            sx={{ display: "inline" }}
+            component="span"
+            color={text_color}
+          >
+            {": "}
+            {result.description}
+          </Typography>
           {result.state === undefined && skipped}
         </>
       );

--- a/src/repo-review-app/index.html
+++ b/src/repo-review-app/index.html
@@ -1,11 +1,8 @@
 <!doctype html>
 <html>
   <head>
-    <meta
-      charset="utf-8"
-      name="viewport"
-      content="initial-scale=1, width=device-width"
-    />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="initial-scale=1, width=device-width" />
     <!-- Fonts to support Material Design -->
     <link
       rel="stylesheet"

--- a/src/repo-review-app/repo-review-app.tsx
+++ b/src/repo-review-app/repo-review-app.tsx
@@ -38,14 +38,22 @@ import {
   prefetch,
   collect_checks,
 } from "./utils/pyodide";
+import type { KnownChecksData } from "./utils/pyodide";
 import type { PyodideInterface } from "pyodide";
-import type { PyProxy } from "pyodide/ffi";
+import type { PyDict, PyIterable, PyProxy } from "pyodide/ffi";
 import type { SelectChangeEvent } from "@mui/material";
 
 const DEFAULT_MSG =
   "Enter a GitHub repo and branch/tag to review. Runs Python entirely in your browser using WebAssembly. Built with React, MaterialUI, and Pyodide.";
 
-interface CheckItem {
+// Build the "About" HTML message. `deps` is app-configured (not user input),
+// so interpolating it into HTML is safe.
+function buildAboutMsg(deps: string[]): string {
+  const deps_str = `<pre><code>${deps.join("\n")}</code></pre>`;
+  return `<p>${DEFAULT_MSG}</p><h4>Packages:</h4> ${deps_str}`;
+}
+
+export interface CheckItem {
   name: string;
   description?: string;
   state?: boolean | null | undefined;
@@ -75,7 +83,7 @@ export interface AppProps {
 
 interface AppState {
   show: string;
-  results: Record<string, CheckItem[]> | CheckItem[];
+  results: Record<string, CheckItem[]> | null;
   pyFamilies: PyProxy | null;
   pyChecks: PyProxy | null;
   snackbarOpen: boolean;
@@ -90,7 +98,10 @@ interface AppState {
   msg: string;
   progress: boolean;
   loadingRefs: boolean;
+  /** App-level error banner text (always plain text, rendered as text content) */
   err_msg: string;
+  /** Render err_msg in a monospace <pre><code> block (e.g. exception text) */
+  err_is_code: boolean;
   skip_reason: string;
   url: string;
   knownChecks: Record<string, CheckItem[]> | null;
@@ -110,8 +121,6 @@ export class App extends React.Component<AppProps, AppState> {
 
   constructor(props: AppProps) {
     super(props);
-    const inner_deps_str = props.deps.join("\n");
-    const deps_str = `<pre><code>${inner_deps_str}</code></pre>`;
     const params = props.disableUrlSync
       ? new URLSearchParams()
       : new URLSearchParams(window.location.search);
@@ -119,7 +128,7 @@ export class App extends React.Component<AppProps, AppState> {
     const initialRefInput = params.get("ref") || "";
     this.state = {
       show: params.get("show") || "all",
-      results: [],
+      results: null,
       pyFamilies: null,
       pyChecks: null,
       snackbarOpen: false,
@@ -131,10 +140,11 @@ export class App extends React.Component<AppProps, AppState> {
       packageDir: sanitizePackageDir(params.get("packageDir") || ""),
       refType: parseRefType(params.get("refType")),
       refs: { branches: [], tags: [] },
-      msg: `<p>${DEFAULT_MSG}</p><h4>Packages:</h4> ${deps_str}`,
+      msg: buildAboutMsg(props.deps),
       progress: false,
       loadingRefs: false,
       err_msg: "",
+      err_is_code: false,
       skip_reason: "",
       url: "",
       knownChecks: null,
@@ -155,7 +165,7 @@ export class App extends React.Component<AppProps, AppState> {
     if (proxy) {
       try {
         proxy.destroy();
-      } catch (e) {
+      } catch {
         // ignore destroy errors
       }
     }
@@ -168,9 +178,23 @@ export class App extends React.Component<AppProps, AppState> {
 
   async fetchRepoReferences(repo: string) {
     if (!repo) return;
+    // Refs are reset whenever the repo changes, so non-empty refs means we
+    // already fetched them for this repo; don't waste the GitHub rate limit.
+    if (
+      this.state.loadingRefs ||
+      this.state.refs.branches.length > 0 ||
+      this.state.refs.tags.length > 0
+    ) {
+      return;
+    }
 
     this.setState({ loadingRefs: true });
     const refs = await fetchRepoRefs(repo);
+    // Drop stale responses if the user switched repos while we were fetching.
+    if (this.state.repo !== repo) {
+      this.setState({ loadingRefs: false });
+      return;
+    }
     this.setState({ refs: refs, loadingRefs: false });
   }
 
@@ -192,8 +216,9 @@ export class App extends React.Component<AppProps, AppState> {
   }
 
   async handleCompute() {
+    if (this.state.progress) return;
     if (!this.state.repo || !this.state.ref) {
-      this.setState({ results: [], msg: DEFAULT_MSG });
+      this.setState({ results: null, msg: buildAboutMsg(this.props.deps) });
       if (!this.props.disableUrlSync) {
         window.history.replaceState(null, "", window.location.pathname);
       }
@@ -221,13 +246,13 @@ export class App extends React.Component<AppProps, AppState> {
         `${window.location.pathname}?${local_params}`,
       );
     }
-    this.setState({ results: [], progress: true, infoOpen: false });
+    this.setState({ results: null, progress: true, infoOpen: false });
     const packageDir = sanitizePackageDir(this.state.packageDir);
     const state = this.state;
     let pyPackage: PyProxy | null = null;
     let collected: PyProxy | null = null;
-    let families_dict: any = null;
-    let results_list: any = null;
+    let families_dict: PyDict | null = null;
+    let results_list: PyIterable | null = null;
     try {
       const pyodide = await this.pyodide_promise!;
       pyPackage = await prefetch(pyodide, state.repo, state.ref, packageDir);
@@ -237,8 +262,12 @@ export class App extends React.Component<AppProps, AppState> {
         pyPackage,
         collected,
         packageDir,
-      ) as any;
-      families_dict = (collected as any).families.copy();
+      ) as PyIterable;
+      // PyProxy.copy() is typed as returning PyProxy; the copy of a dict
+      // proxy is still a dict proxy.
+      families_dict = (
+        collected as PyProxy & { families: PyDict }
+      ).families.copy() as PyDict;
 
       const results: Record<string, CheckItem[]> = {};
       const families: Record<string, { name: string; description?: string }> =
@@ -275,6 +304,7 @@ export class App extends React.Component<AppProps, AppState> {
         families: families,
         progress: false,
         err_msg: "",
+        err_is_code: false,
         url: "",
         infoOpen: false,
         pyFamilies: families_dict,
@@ -295,11 +325,15 @@ export class App extends React.Component<AppProps, AppState> {
         this.setState({
           progress: false,
           err_msg: "Invalid repository or branch/tag. Please try again.",
+          err_is_code: false,
         });
       } else {
+        // Stored as plain text and rendered as React text content (never as
+        // raw HTML) — exception messages can echo unsanitized URL input.
         this.setState({
           progress: false,
-          err_msg: `<pre><code>${emsg}</code></pre>`,
+          err_msg: emsg,
+          err_is_code: true,
         });
       }
     } finally {
@@ -347,9 +381,8 @@ export class App extends React.Component<AppProps, AppState> {
         return;
       }
 
-      const htmlStr = htmlOut.toString ? htmlOut.toString() : htmlOut;
       if (navigator.clipboard && navigator.clipboard.writeText) {
-        await navigator.clipboard.writeText(htmlStr);
+        await navigator.clipboard.writeText(htmlOut);
         this.setState({
           snackbarOpen: true,
           snackbarMsg: "HTML output copied to clipboard",
@@ -359,7 +392,7 @@ export class App extends React.Component<AppProps, AppState> {
         // Fallback: open in new window for manual copy
         const w = window.open("", "repo-review-html");
         if (w) {
-          w.document.write(htmlStr);
+          w.document.write(htmlOut);
           w.document.close();
         }
       }
@@ -376,8 +409,7 @@ export class App extends React.Component<AppProps, AppState> {
 
   async loadKnownChecks() {
     const pyodide = await this.pyodide_promise!;
-    let data: { families?: Record<string, { name: string }>; results?: any[] } =
-      {};
+    let data: KnownChecksData = {};
     try {
       data = load_known_checks(pyodide);
     } catch (e) {
@@ -424,6 +456,16 @@ export class App extends React.Component<AppProps, AppState> {
           pyodideMessage: m || "",
         }),
     );
+    // Surface load failures in the error banner instead of failing silently.
+    this.pyodide_promise.catch((e: unknown) => {
+      const emsg = (e as Error)?.message || String(e);
+      this.setState({
+        pyodideLoading: false,
+        progress: false,
+        err_msg: `Failed to load Pyodide: ${emsg}`,
+        err_is_code: true,
+      });
+    });
     if (!this.props.disableUrlSync) {
       const params = new URLSearchParams(window.location.search);
       if (params.get("repo")) {
@@ -431,10 +473,14 @@ export class App extends React.Component<AppProps, AppState> {
       }
       if (params.get("repo") && params.get("ref")) {
         this.handleCompute();
-        return;
       }
     }
-    this.pyodide_promise.then(() => this.loadKnownChecks());
+    // Always load the list of available checks, even if an auto-run from the
+    // URL parameters is in flight (or fails). Errors are reported above.
+    this.pyodide_promise.then(
+      () => this.loadKnownChecks(),
+      () => {},
+    );
   }
 
   render() {
@@ -497,12 +543,10 @@ export class App extends React.Component<AppProps, AppState> {
       ];
     }
 
-    const hasResults = !Array.isArray(this.state.results);
-    const displayResults = hasResults
-      ? this.state.results
-      : !this.state.progress && this.state.knownChecks
-        ? this.state.knownChecks
-        : null;
+    const hasResults = this.state.results !== null;
+    const displayResults =
+      this.state.results ??
+      (!this.state.progress ? this.state.knownChecks : null);
     const displayFamilies = hasResults
       ? this.state.families
       : this.state.knownFamilies;
@@ -514,14 +558,9 @@ export class App extends React.Component<AppProps, AppState> {
     let filteredResults = displayResults;
     let filteredFamilies = displayFamilies;
     if (displayResults && this.state.show && this.state.show !== "all") {
-      const groupedResults = displayResults as Record<string, CheckItem[]>;
-      const groupedFamilies = displayFamilies as Record<
-        string,
-        { name: string; description?: string }
-      >;
       const newResults: Record<string, CheckItem[]> = {};
-      for (const fam of Object.keys(groupedResults)) {
-        const items = groupedResults[fam];
+      for (const fam of Object.keys(displayResults)) {
+        const items = displayResults[fam];
         // first keep items that are not passing (i.e., state !== true)
         let kept = items.filter((it: CheckItem) => it.state !== true);
         // if 'err', then keep only failing checks
@@ -538,12 +577,12 @@ export class App extends React.Component<AppProps, AppState> {
         string,
         { name: string; description?: string }
       > = {};
-      for (const k of Object.keys(groupedFamilies)) {
+      for (const k of Object.keys(displayFamilies)) {
         if (
           knownFamilies.has(k) ||
-          (groupedFamilies[k] && groupedFamilies[k].description)
+          (displayFamilies[k] && displayFamilies[k].description)
         ) {
-          newFamilies[k] = groupedFamilies[k];
+          newFamilies[k] = displayFamilies[k];
         }
       }
 
@@ -622,16 +661,18 @@ export class App extends React.Component<AppProps, AppState> {
                   helperText="e.g. HEAD, main, or v1.0.0"
                   onFocus={() => this.fetchRepoReferences(this.state.repo)}
                   sx={{ flexGrow: 2, minWidth: 170 }}
-                  InputProps={{
-                    ...params.InputProps,
-                    endAdornment: (
-                      <>
-                        {this.state.loadingRefs ? (
-                          <CircularProgress color="inherit" size={20} />
-                        ) : null}
-                        {params.InputProps.endAdornment}
-                      </>
-                    ),
+                  slotProps={{
+                    input: {
+                      ...params.InputProps,
+                      endAdornment: (
+                        <>
+                          {this.state.loadingRefs ? (
+                            <CircularProgress color="inherit" size={20} />
+                          ) : null}
+                          {params.InputProps.endAdornment}
+                        </>
+                      ),
+                    },
                   }}
                 />
               )}
@@ -727,6 +768,7 @@ export class App extends React.Component<AppProps, AppState> {
                 onClick={() => this.handleCompute()}
                 variant="contained"
                 size="large"
+                aria-label="Run checks"
                 disabled={
                   this.state.progress || !this.state.repo || !this.state.ref
                 }
@@ -787,12 +829,19 @@ export class App extends React.Component<AppProps, AppState> {
                 color="error"
                 sx={{ p: 2 }}
               >
-                <span
-                  dangerouslySetInnerHTML={{ __html: this.state.err_msg }}
-                />
+                {this.state.err_is_code ? (
+                  <Box
+                    component="pre"
+                    sx={{ m: 0, whiteSpace: "pre-wrap", overflowX: "auto" }}
+                  >
+                    <code>{this.state.err_msg}</code>
+                  </Box>
+                ) : (
+                  this.state.err_msg
+                )}
               </Typography>
             )}
-            {displayResults && (
+            {filteredResults && (
               <>
                 <Box
                   sx={{ display: "flex", alignItems: "center", px: 2, pt: 1 }}
@@ -804,6 +853,7 @@ export class App extends React.Component<AppProps, AppState> {
                     <Button
                       onClick={() => this.handleCopyHtml()}
                       size="small"
+                      aria-label="Copy HTML results"
                       disabled={
                         this.state.progress || this.state.pyodideLoading
                       }
@@ -828,7 +878,7 @@ export class App extends React.Component<AppProps, AppState> {
         >
           <Alert
             onClose={() => this.setState({ snackbarOpen: false })}
-            severity={this.state.snackbarSeverity as any}
+            severity={this.state.snackbarSeverity}
             sx={{ width: "100%" }}
           >
             {this.state.snackbarMsg}

--- a/src/repo-review-app/utils/github.test.ts
+++ b/src/repo-review-app/utils/github.test.ts
@@ -69,6 +69,19 @@ describe("fetchRepoRefs", () => {
     expect(result.tags).toHaveLength(2);
   });
 
+  it("requests 100 results per page to avoid truncation", async () => {
+    const urls: string[] = [];
+    globalThis.fetch = (async (input: string | URL | Request) => {
+      urls.push(input.toString());
+      return new Response("[]", { status: 200 });
+    }) as unknown as typeof globalThis.fetch;
+    await fetchRepoRefs("owner/repo");
+    expect(urls).toHaveLength(2);
+    for (const url of urls) {
+      expect(url).toContain("per_page=100");
+    }
+  });
+
   it("returns empty arrays when the API responds with a non-OK status", async () => {
     globalThis.fetch = makeFetchMock(null, null, 404);
     const result = await fetchRepoRefs("owner/repo");

--- a/src/repo-review-app/utils/github.ts
+++ b/src/repo-review-app/utils/github.ts
@@ -1,9 +1,10 @@
 export async function fetchRepoRefs(repo: string) {
   if (!repo) return { branches: [], tags: [] };
   try {
+    // Default page size is 30; request the maximum to avoid truncating refs.
     const [branchesResponse, tagsResponse] = await Promise.all([
-      fetch(`https://api.github.com/repos/${repo}/branches`),
-      fetch(`https://api.github.com/repos/${repo}/tags`),
+      fetch(`https://api.github.com/repos/${repo}/branches?per_page=100`),
+      fetch(`https://api.github.com/repos/${repo}/tags?per_page=100`),
     ]);
 
     if (!branchesResponse.ok || !tagsResponse.ok) {

--- a/src/repo-review-app/utils/pyodide.ts
+++ b/src/repo-review-app/utils/pyodide.ts
@@ -10,33 +10,30 @@ export async function prepare_pyodide(
   pyodideBaseUrl?: string,
   onProgress?: (p: number, m?: string) => void,
 ): Promise<PyodideInterface> {
-  try {
-    if (onProgress) onProgress(5, "Initializing Pyodide runtime");
-    const baseUrl = pyodideBaseUrl ?? DEFAULT_PYODIDE_BASE_URL;
-    const { loadPyodide } = (await import(`${baseUrl}/pyodide.mjs`)) as {
-      loadPyodide: () => Promise<PyodideInterface>;
-    };
-    const pyodide: PyodideInterface = await loadPyodide();
-    if (onProgress) onProgress(50, "Core Pyodide loaded");
+  // On failure the promise rejects; callers are responsible for surfacing
+  // the error (the app shows it in the error banner).
+  if (onProgress) onProgress(5, "Initializing Pyodide runtime");
+  const baseUrl = pyodideBaseUrl ?? DEFAULT_PYODIDE_BASE_URL;
+  const { loadPyodide } = (await import(`${baseUrl}/pyodide.mjs`)) as {
+    loadPyodide: () => Promise<PyodideInterface>;
+  };
+  const pyodide: PyodideInterface = await loadPyodide();
+  if (onProgress) onProgress(50, "Core Pyodide loaded");
 
-    if (onProgress) onProgress(65, "Loading micropip");
-    await pyodide.loadPackage("micropip");
-    if (onProgress) onProgress(80, "Installing Python packages");
+  if (onProgress) onProgress(65, "Loading micropip");
+  await pyodide.loadPackage("micropip");
+  if (onProgress) onProgress(80, "Installing Python packages");
 
-    // Pass deps via globals instead of string interpolation for safety
-    pyodide.globals.set("_rr_deps_to_install", deps);
-    await pyodide.runPythonAsync(`
-      import micropip
-      await micropip.install(list(_rr_deps_to_install))
-    `);
-    pyodide.globals.delete("_rr_deps_to_install");
+  // Pass deps via globals instead of string interpolation for safety
+  pyodide.globals.set("_rr_deps_to_install", deps);
+  await pyodide.runPythonAsync(`
+    import micropip
+    await micropip.install(list(_rr_deps_to_install))
+  `);
+  pyodide.globals.delete("_rr_deps_to_install");
 
-    if (onProgress) onProgress(100, "Ready");
-    return pyodide;
-  } catch (e) {
-    if (onProgress) onProgress(100, "Error during load");
-    throw e;
-  }
+  if (onProgress) onProgress(100, "Ready");
+  return pyodide;
 }
 
 export async function prefetch(
@@ -100,10 +97,18 @@ export function run_process(
   return checks;
 }
 
-export function load_known_checks(
-  pyodide: PyodideInterface,
-): Record<string, unknown> {
-  const dataStr = pyodide.runPython(`
+export interface KnownChecksData {
+  families?: Record<string, { name: string }>;
+  results?: {
+    name: string;
+    family: string;
+    description: string;
+    url: string;
+  }[];
+}
+
+export function load_known_checks(pyodide: PyodideInterface): KnownChecksData {
+  const dataStr: string = pyodide.runPython(`
     import json
     from repo_review.processor import collect_all
     from repo_review.checks import get_check_url
@@ -122,8 +127,8 @@ export function load_known_checks(
     json.dumps({"families": families_out, "results": results_out})
     `);
 
-  // pyodide may return a PyProxy; ensure string
-  return JSON.parse(dataStr.toString ? dataStr.toString() : dataStr);
+  // Python `str` converts directly to a JS string
+  return JSON.parse(dataStr) as KnownChecksData;
 }
 
 export async function generate_html(
@@ -136,7 +141,7 @@ export async function generate_html(
   pyodide.globals.set("checks_for_html", checksPy);
   pyodide.globals.set("show_for_html", show || "all");
 
-  const htmlOut = await pyodide.runPythonAsync(`
+  const htmlOut: string = await pyodide.runPythonAsync(`
     from repo_review.html import to_html
 
     match show_for_html:
@@ -152,5 +157,6 @@ export async function generate_html(
     to_html(families_for_html, filtered)
     `);
 
-  return htmlOut.toString ? htmlOut.toString() : htmlOut;
+  // Python `str` converts directly to a JS string
+  return htmlOut;
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Hardens and polishes the TypeScript/React webapp. No Python changes.

## Security

- **Reflected XSS in the error banner**: on compute failure, the raw exception message (which echoes the URL built from unsanitized `?repo=`/`?ref=` query parameters) was interpolated into an HTML string and rendered with `dangerouslySetInnerHTML`. The app-level error is now stored as plain text and rendered as React text content inside a styled `<pre><code>` block. Per-check `err_msg` HTML from Python (rendered in `Results.tsx`) is unchanged.

## Bugs

- **ESLint was a silent no-op**: the flat config had no `files` key, so no `.ts`/`.tsx` file was ever matched and zero rules were enabled. Rewritten using the `typescript-eslint` meta-package + `eslint-plugin-react` (recommended + jsx-runtime) + `eslint-plugin-react-hooks` + `eslint-config-prettier`, with proper coverage of `src/**/*.{ts,tsx}`. Dropped the legacy `--ext` flag, the `createRequire` workaround, and the now-redundant `@typescript-eslint/parser`/`@typescript-eslint/eslint-plugin` devDependencies. Note: `react.settings.version` is pinned to `19` because the plugin's `detect` mode crashes under ESLint 10.
- **Concurrent compute race**: Enter-key handlers on the repo/ref fields called `handleCompute()` unconditionally while a run was in progress; it now bails if `progress` is set.
- **Stale-response race in `fetchRepoReferences`**: a slow refs fetch for a previous repo could overwrite state after switching repos; stale responses are now dropped, and already-loaded refs are not refetched on every focus (saves the unauthenticated GitHub rate limit).
- **Pyodide load failures were invisible**: the rejection now surfaces in the error banner and the `loadKnownChecks` chain has a rejection handler (previously an unhandled rejection).
- **Auto-run skipped `loadKnownChecks`**: when the URL had `repo`+`ref`, an early return meant the available-checks list never loaded if that run failed.
- **GitHub refs truncated to 30**: branch/tag fetches now request `per_page=100` (with a test).

## Cleanup

- MUI deprecated `InputProps` → `slotProps={{ input: ... }}`.
- `results` state simplified to `Record<string, CheckItem[]> | null`, removing the `Array.isArray` sentinel logic and casts.
- Removed dead `toString` ternary guards on values already typed `string`.
- Replaced easy `any` types with proper interfaces (`Results`, `Heading`, `MyThemeProvider`, `PyDict`/`PyIterable` proxy typing, snackbar severity).
- Factored the About message construction into one helper so the reset path keeps the `<p>` wrapper and packages list.
- Replaced the `<IfUrlLink name=': ' url=''>` separator hack with plain text and removed a redundant fragment.
- Added `aria-label`s to the icon-only Run/Copy buttons.
- Split the merged `charset`/`viewport` meta tag in `index.html` (the viewport was being ignored).
- Removed unused `import React` defaults (automatic JSX runtime).

## Validation

- `bun run type`, `bun run lint` (verified it now actually lints `.tsx`), `bun test` (22 pass), `bun run build`, and `uv run pytest` (45 pass) all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)