### PR TITLE
ci: unblock docs build broken by erbsland-sphinx-ansi 1.2.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,6 +101,10 @@ installer = "uv"
 
 [tool.uv]
 exclude-newer = "7 days"
+# erbsland-sphinx-ansi 1.2.4 fixes a crash with Sphinx 9.1 / docutils 0.22; the
+# broken 1.2.2 is inside the 7-day window while the fix is not. Remove this once
+# 1.2.4 ages past the window (after 2026-06-17).
+exclude-newer-package = { "erbsland-sphinx-ansi" = "2026-06-11" }
 
 [tool.hatch.envs.hatch-test]
 features = ["cli"]


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Problem

CI's **Docs** job was failing on `main` (all other jobs green). Two independent regressions, both surfaced as recent releases aged into the `exclude-newer = "7 days"` window:

1. **Hard crash** — `erbsland-sphinx-ansi` **1.2.2** (May 28) ships an `ANSILiteralBlock` incompatible with Sphinx 9.1 / docutils 0.22. `sphinxcontrib-programoutput` passes it a `str` as a child node and docutils throws `'str' object has no attribute 'parent'`, aborting Linkcheck:
   ```
   ExtensionError: Handler run_programs ... 'str' object has no attribute 'parent'
   ```
   Fixed upstream in **1.2.4** (wraps the text in a `nodes.Text`) — but the 7-day window admitted the broken 1.2.2 while excluding the fix.

2. **Latent linkcheck failure** behind it — `sphinx-github-changelog` **2.3.0** (also newly in-window) now renders the full changelog anonymously in CI (the old version left it empty without a token), exposing two broken 404s in old release notes: a `scienific-python` typo in v1.0.0 and a bad `v0.7.0b8...v0.7.0rc1` compare in v0.7.0b9.

## Fix

- **This PR**: a per-package `exclude-newer` override so the 1.2.4 fix is allowed now. The comment notes it can be removed after 2026-06-17, when 1.2.4 naturally ages past the 7-day window.
- **Already applied directly on GitHub** (outside this PR): fixed the two broken links in the v1.0.0 and v0.7.0b9 release notes.

## Verification

Under CI conditions (clean build, `GITHUB_API_TOKEN` unset, no git auth):

- `hatch run docs:linkcheck` → exit 0
- `hatch run docs:html -W` → exit 0
- `hatch run api-docs:build && git diff --exit-code` → clean