### PR TITLE
chore: update Pyodide to 314.0.0 (Python 3.14)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -9,7 +9,7 @@
         "@emotion/styled": "^11.14.1",
         "@mui/icons-material": "7",
         "@mui/material": "^7.3.9",
-        "pyodide": "^0.29.3",
+        "pyodide": "^314.0.0",
         "react": "^19.2.4",
         "react-dom": "^19.2.4",
       },
@@ -571,7 +571,7 @@
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
-    "pyodide": ["pyodide@0.29.3", "", { "dependencies": { "@types/emscripten": "^1.41.4", "ws": "^8.5.0" } }, "sha512-22UBuhOJawj7vKUnS7/F3xK+515LJdjiMAHoCfuS6/PbHiOrSQVnYwDe+2sbVwiOZ3sMMexdXICew6NqOMQGgA=="],
+    "pyodide": ["pyodide@314.0.0", "", { "dependencies": { "@types/emscripten": "^1.41.4", "ws": "^8.5.0" } }, "sha512-WIofRQehY78IC9n3+p9COjKUZGCCHfrvtR5dXKm0BHIWUun2B8DBf17rXytMF/KYkrsDQRa+BDGhi8UKwzaU3w=="],
 
     "react": ["react@19.2.4", "", {}, "sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ=="],
 

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@emotion/styled": "^11.14.1",
     "@mui/icons-material": "7",
     "@mui/material": "^7.3.9",
-    "pyodide": "^0.29.3",
+    "pyodide": "^314.0.0",
     "react": "^19.2.4",
     "react-dom": "^19.2.4"
   }

--- a/src/repo-review-app/anywidget.tsx
+++ b/src/repo-review-app/anywidget.tsx
@@ -6,7 +6,7 @@
  * ```{anywidget} repo-review-anywidget.mjs
  * {
  *   "deps": ["repo-review", "sp-repo-review"],
- *   "pyodide_base_url": "https://cdn.jsdelivr.net/pyodide/v0.29.3/full"
+ *   "pyodide_base_url": "https://cdn.jsdelivr.net/pyodide/v314.0.0/full"
  * }
  * ```
  *


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Updates the webapp from Pyodide `0.29.3` to `314.0.0`. Pyodide adopted a new versioning scheme — `314.0.0` bundles **Python 3.14.2**, replacing the `0.29.x` line.

## Changes
- `package.json`: `pyodide` `^0.29.3` → `^314.0.0`
- `bun.lock`: regenerated (`pyodide@314.0.0`)
- `anywidget.tsx`: bumped the CDN example URL in the docstring to `v314.0.0`

The CDN base URL in `utils/pyodide.ts` is derived from the npm package version at build time, so it picks up the new version automatically. Confirmed jsDelivr serves `v314.0.0/full/pyodide.mjs`.

## Changelog review — no code changes needed
Checked the 314.0.0 breaking changes against our usage:

| Breaking change | Affects us? |
|---|---|
| `pyodide.asm.js` → `pyodide.asm.mjs`; classic workers dropped | **No** — we import `pyodide.mjs` from the CDN; the rename is internal to the loader, and we do not use workers. |
| `ssl` is now a stub (SSL ops raise `NotImplementedError`) | **No** — in the browser, `ghpath.py` fetches via `pyodide.http.pyfetch` (JS `fetch`), not Python `ssl`/`httpx`/`urllib`. |
| OpenSSL `hashlib` hashes removed | **No** — not used in the Pyodide path. |
| `pydecimal`/`test` removed; `pydoc_data` needs explicit load; `fullstdlib` deprecated | **No** — none used; we do not pass `fullstdlib`. |
| `sqlite3`/`lzma` bundled; `compression.zstd` added; FFI additions | Additive — no action. |

We only use `loadPackage("micropip")` + `micropip.install(...)`, both unchanged.

> [!NOTE]
> `^314.0.0` pins to the 3.14 series (`>=314.0.0 <315.0.0`), matching how the old `^0.29.x` pin behaved.

## Validation
- `bun run type` ✅
- `bun run build` ✅
- `bun run lint` ✅
- `prek -a` ✅