### PR TITLE
fix(webapp): restore Autocomplete input ref under MUI v9

### DIFF
--- a/src/repo-review-app/repo-review-app.tsx
+++ b/src/repo-review-app/repo-review-app.tsx
@@ -585,6 +585,7 @@ export class App extends React.Component<AppProps, AppState> {
                   onFocus={() => this.fetchRepoReferences(this.state.repo)}
                   sx={{ flexGrow: 2, minWidth: 170 }}
                   slotProps={{
+                    ...params.slotProps,
                     input: {
                       ...params.slotProps.input,
                       endAdornment: (


### PR DESCRIPTION
Fixed in Claude desktop - watching it manipulate a webpage in the live preview is still novel to me. :)

:robot: _AI text below_ :robot:

## What

The Branch/Tag dropdown in the webapp was invisible and crashed the app on click, with these console errors:

- `MUI: Unable to find the input element. It was resolved to null while an HTMLInputElement was expected.`
- `TypeError: null is not an object (evaluating 'fe.current.focus')`
- `TypeError: null is not an object (evaluating 'fe.current.removeAttribute')`

## Why

Not the web-worker move (#404) — that was just the next deploy. The real cause is the **MUI Material v7 → v9 bump in #400**.

The `Autocomplete`'s `renderInput` customizes the `TextField` to add the loading spinner, passing an explicit `slotProps={{ input: ... }}`. In MUI v7 the input ref lived in separate top-level `renderInput` params that `{...params}` carried through, so this was harmless. In v9 those params were consolidated into a single `slotProps` object with siblings `input`, **`htmlInput` (which carries the `ref` to the underlying `<input>`)**, and `inputLabel`. Overriding `slotProps` wholesale dropped `htmlInput`, so the input ref was never attached. `inputRef.current` stayed `null`, the popup couldn't anchor, and `focus()`/`removeAttribute()` on the null ref crashed the app.

## Fix

Spread `...params.slotProps` before overriding `input`, preserving `htmlInput` and `inputLabel`:

```tsx
slotProps={{
  ...params.slotProps,
  input: {
    ...params.slotProps.input,
    endAdornment: ( /* spinner + existing adornment */ ),
  },
}}
```

## Verification

- Reproduced the crash locally, applied the fix, confirmed via DOM eval that the dropdown opens with options, the input focuses, and the app root stays mounted (no crash).
- `bun run type` passes.

## Reviewer note

This kind of runtime-only regression slips past the type-checker, so a wide major bump like v7→v9 warrants a manual webapp smoke test.